### PR TITLE
Separate banner visibility from openconnect verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ automatically on first run.
 `~/.config/vpn-up/vpn-up.command.config`
 
 ```bash
-readonly QUIET=TRUE
+readonly QUIET=TRUE          # openconnect output verbosity
 readonly BACKGROUND=TRUE
+readonly SHOW_BANNER=TRUE    # ASCII banner on start (independent of QUIET)
 readonly ENCRYPTION_ENABLED=TRUE
 ```
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -52,7 +52,7 @@ doctor() {
   echo
   echo "Config preview:"
   if [ -f "$CONFIGURATION_FILE" ]; then
-    grep -E '^(readonly (SUDO|BACKGROUND|QUIET|ENCRYPTION_ENABLED))' "$CONFIGURATION_FILE" || true
+    grep -E '^(readonly (SUDO|BACKGROUND|QUIET|SHOW_BANNER|ENCRYPTION_ENABLED))' "$CONFIGURATION_FILE" || true
   else
     echo "  (no config yet; run ./vpn-up.command setup)"
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -39,12 +39,18 @@ readonly QUIET=__QUIET__
 #        ├ TRUE          Less output
 #        └ FALSE         Detailed output
 
+# UI
+readonly SHOW_BANNER=__SHOW_BANNER__
+#        ├ TRUE          Show the ASCII banner on start (interactive only)
+#        └ FALSE         Never show the banner
+
 # ENCRYPTION
 readonly ENCRYPTION_ENABLED=TRUE  # Toggle affects only file fallback; keychain/keyring are preferred.
 CFG
   sed -i.bak "s/__SUDO__/${__WZ_SUDO}/" "${tmp}"
   sed -i.bak "s/__BACKGROUND__/${__WZ_BACKGROUND}/" "${tmp}"
   sed -i.bak "s/__QUIET__/${__WZ_QUIET}/" "${tmp}"
+  sed -i.bak "s/__SHOW_BANNER__/${__WZ_SHOW_BANNER}/" "${tmp}"
   rm -f "${tmp}.bak"
   mv "${tmp}" "${CONFIGURATION_FILE}"
   chmod 600 "${CONFIGURATION_FILE}"
@@ -62,6 +68,9 @@ setup_wizard() {
 
   read -r -p "Quiet output? (TRUE/FALSE) [TRUE]: " _in_quiet
   __WZ_QUIET="$(_bool_default "${_in_quiet}" "TRUE")"
+
+  read -r -p "Show ASCII banner on start? (TRUE/FALSE) [TRUE]: " _in_banner
+  __WZ_SHOW_BANNER="$(_bool_default "${_in_banner}" "TRUE")"
 
   # Clean up any sudo password stored by older versions; storing it defeats
   # sudo's protection (any process running as this user could retrieve it).

--- a/ui.sh
+++ b/ui.sh
@@ -19,8 +19,9 @@ PRIMARY="${PRIMARY:-\x1b[36;1m}"
 RESET="${RESET:-\x1b[0m}"
 
 show_banner() {
-  # Only show when interactive and not quiet
-  [ -t 1 ] || return
-  [ "${QUIET:-FALSE}" = TRUE ] && return
+  # Only show when interactive and enabled; independent of QUIET, which
+  # controls openconnect's output verbosity.
+  [ -t 1 ] || return 0
+  [ "${SHOW_BANNER:-TRUE}" = TRUE ] || return 0
   printf "%b\n" "${PRIMARY}${ASCII_ART}${RESET}"
 }


### PR DESCRIPTION
Adds a `SHOW_BANNER` config setting (default `TRUE`) so the start-up ASCII banner is controlled independently of `QUIET`, which now governs only openconnect output verbosity.