### PR TITLE
v3.2.0: scriptable CLI — named start, list, logs, richer status, pin --save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.2.0] — 2026-06-12
+### Scriptability & CLI Update
+
+### Added
+- `start [profile]` / `restart [profile]` — connect directly by profile name,
+  no interactive menu; with a stored secret the only interaction left is 2FA.
+- `list` — tabular overview of configured profiles (name, protocol, host,
+  2FA method; no secrets shown).
+- `logs [-f]` — show the connection log, or follow it live.
+- `pin --save <profile>` — fetch the gateway's `pin-sha256` and write it into
+  the profile's `<serverCertificate>` directly.
+- Richer `status`: connected profile, gateway, connect time, and uptime
+  (recorded in a state file at connect, removed on stop).
+
+### Changed
+- A `duo2FAMethod` of `passcode` now prompts for the one-time code at connect
+  time instead of reading a stale value from the XML.
+
+---
+
 ## [v3.1.0] — 2026-06-12
 ### UI Update
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This project is intended for **legitimate and authorized VPN access only**.
   - Pulse Secure
 - Duo 2FA support:
   - `push`, `phone`, `sms`, or 6-digit passcode
+  - `passcode` in the profile prompts for the one-time code at connect time
   - Empty 2FA field allows gateway auto-push
 - Correct handling of **AuthGroup** (realm) selection
 
@@ -185,8 +186,11 @@ readonly ENCRYPTION_ENABLED=TRUE
 
 ### Basic Commands
 ```bash
-./vpn-up.command start
-./vpn-up.command status
+./vpn-up.command start                  # interactive profile menu
+./vpn-up.command start "Frankfurt VPN"  # connect directly (scriptable)
+./vpn-up.command list                   # list configured profiles
+./vpn-up.command status                 # profile, gateway, uptime
+./vpn-up.command logs -f                # follow the connection log
 ./vpn-up.command stop
 ```
 
@@ -217,9 +221,11 @@ sudo visudo -cf /etc/sudoers.d/vpn-up   # validate
 
 ### Certificate pinning
 ```bash
-./vpn-up.command pin vpn.example.com
+./vpn-up.command pin vpn.example.com          # print the pin
+./vpn-up.command pin --save "Frankfurt VPN"   # write it into the profile
 ```
-Prints the gateway's `pin-sha256:...` value for `<serverCertificate>`.
+Prints the gateway's `pin-sha256:...` value for `<serverCertificate>`,
+or saves it into the profile directly with `--save`.
 If no pin is configured, the gateway's certificate **must** validate against
 the system trust store or the connection is refused (fail closed). Legacy
 SHA1 pins still work but print a deprecation warning — re-pin with the

--- a/core.sh
+++ b/core.sh
@@ -17,6 +17,7 @@ assert_safe_to_source() {
 }
 
 start() {
+  local requested="${1:-}"
   # Ensure config exists or run wizard
   if [ ! -f "$CONFIGURATION_FILE" ]; then
     setup_wizard
@@ -52,31 +53,52 @@ start() {
   print_warning "Process ID (PID) stored in %s ...\n" "${PID_FILE_PATH}"
   print_warning "Logs file (LOG) stored in %s ...\n" "${LOG_FILE_PATH}"
 
-  # Select a profile (modern Bash mapfile)
-  mapfile -t vpn_names < <(list_profile_names)
-  PS3=$'Choose VPN: '
-  select option in "${vpn_names[@]}"; do
-    if [ "$option" = "Quit" ]; then
-      print_warning "You chose to close the app!\n"
-      exit 0
+  if [ -n "$requested" ]; then
+    # Non-interactive: profile named on the command line
+    if ! profile_exists "$requested"; then
+      print_danger "Unknown profile '%s'. Available profiles:\n" "$requested"
+      list_profiles
+      exit 1
     fi
-    if printf "%s\n" "${vpn_names[@]}" | grep -qx -- "$option"; then
-      load_profile_fields "$option"
-      migrate_or_fetch_password
-      connect
-      break
-    else
-      print_danger "Invalid option! Please choose one of the options above...\n"
-    fi
-  done
+    load_profile_fields "$requested"
+    migrate_or_fetch_password
+    connect
+  else
+    # Interactive profile selection (modern Bash mapfile)
+    mapfile -t vpn_names < <(list_profile_names)
+    PS3=$'Choose VPN: '
+    select option in "${vpn_names[@]}"; do
+      if [ "$option" = "Quit" ]; then
+        print_warning "You chose to close the app!\n"
+        exit 0
+      fi
+      if printf "%s\n" "${vpn_names[@]}" | grep -qx -- "$option"; then
+        load_profile_fields "$option"
+        migrate_or_fetch_password
+        connect
+        break
+      else
+        print_danger "Invalid option! Please choose one of the options above...\n"
+      fi
+    done
+  fi
 
   if is_vpn_running; then
+    write_connection_state
     print_success "Connected to %s\n" "${VPN_NAME}"
     print_current_ip_address
   else
     print_danger "Failed to connect! Last log lines from %s:\n" "${LOG_FILE_PATH}"
     tail -n 15 "$LOG_FILE_PATH" 2>/dev/null || true
   fi
+}
+
+# Record which profile is connected so `status` can report it.
+write_connection_state() {
+  ( umask 077
+    printf 'profile=%s\nhost=%s\nconnected_at=%s\n' \
+      "${VPN_NAME}" "${VPN_HOST}" "$(date '+%Y-%m-%d %H:%M:%S')" > "$STATE_FILE_PATH"
+  )
 }
 
 connect() {
@@ -87,6 +109,16 @@ connect() {
   if [ -z "${PROTOCOL}" ]; then
     print_danger "Variable 'PROTOCOL' is not declared! Update it in %s ...\n" "${PROFILES_FILE}"
     return 1
+  fi
+
+  # Duo passcodes are one-time values; never read them from the XML —
+  # prompt at connect time instead.
+  if [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
+    read -r -p "Enter Duo passcode for ${VPN_NAME}: " VPN_DUO2FAMETHOD
+    if [ -z "$VPN_DUO2FAMETHOD" ]; then
+      print_danger "No passcode entered; aborting.\n"
+      return 1
+    fi
   fi
 
   set_protocol_description
@@ -119,7 +151,18 @@ connect() {
 
 status() {
   if is_vpn_running; then
-    print_success "VPN is running (PID: %s)\n" "$(cat "$PID_FILE_PATH")"
+    local pid; pid="$(cat "$PID_FILE_PATH")"
+    print_success "VPN is running (PID: %s)\n" "$pid"
+    if [ -f "$STATE_FILE_PATH" ]; then
+      local profile host connected_at
+      profile="$(awk -F= '$1=="profile"{print substr($0,9); exit}' "$STATE_FILE_PATH")"
+      host="$(awk -F= '$1=="host"{print substr($0,6); exit}' "$STATE_FILE_PATH")"
+      connected_at="$(awk -F= '$1=="connected_at"{print substr($0,14); exit}' "$STATE_FILE_PATH")"
+      print_primary "  Profile : %s\n" "${profile:-unknown}"
+      print_primary "  Gateway : %s\n" "${host:-unknown}"
+      print_primary "  Since   : %s\n" "${connected_at:-unknown}"
+    fi
+    print_primary "  Uptime  : %s\n" "$(ps -p "$pid" -o etime= 2>/dev/null | tr -d ' ' || echo unknown)"
   else
     print_warning "VPN is not running.\n"
   fi
@@ -133,7 +176,7 @@ stop() {
   local pid; pid="$(cat "$PID_FILE_PATH")"
   if ! is_openconnect_pid "$pid"; then
     print_warning "Stale PID file (no openconnect process with PID %s); cleaning up.\n" "$pid"
-    rm -f "$PID_FILE_PATH"
+    rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
     return 0
   fi
   # openconnect runs as root, so killing it needs sudo too.
@@ -155,7 +198,7 @@ stop() {
     print_danger "Could not stop openconnect (PID: %s); VPN may still be up!\n" "$pid"
     return 1
   fi
-  rm -f "$PID_FILE_PATH"
+  rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
   print_success "VPN stopped.\n"
 }
 

--- a/logging.sh
+++ b/logging.sh
@@ -3,6 +3,20 @@
 PID_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.pid"
 # shellcheck disable=SC2034  # used by core.sh
 LOG_FILE_PATH="${DATA_DIR}/logs/${PROGRAM_NAME}.log"
+# shellcheck disable=SC2034  # used by core.sh
+STATE_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.state"
+
+show_logs() {
+  if [ ! -f "$LOG_FILE_PATH" ]; then
+    print_warning "No log file yet at %s\n" "$LOG_FILE_PATH"
+    return 0
+  fi
+  if [ "${1:-}" = "-f" ]; then
+    tail -f "$LOG_FILE_PATH"
+  else
+    tail -n 50 "$LOG_FILE_PATH"
+  fi
+}
 
 # Color codes are printed separately from the message so they never go
 # through printf format processing; data must be passed as arguments to a

--- a/network.sh
+++ b/network.sh
@@ -26,6 +26,41 @@ verify_gateway_cert() {
     </dev/null >/dev/null 2>&1
 }
 
+# Fetch a profile's gateway pin and write it into <serverCertificate>.
+pin_save() {
+  local profile="$1"
+  check_file_existence "$PROFILES_FILE" "Profiles"
+  if ! profile_exists "$profile"; then
+    print_danger "Unknown profile '%s'.\n" "$profile"
+    return 1
+  fi
+  local name_lit; name_lit="$(xpath_literal "$profile")"
+  local host; host="$(xmlstarlet sel -t -m "//VPN[name=${name_lit}]" -v host "${PROFILES_FILE}")"
+  if [ -z "$host" ]; then
+    print_danger "Profile '%s' has no <host> configured.\n" "$profile"
+    return 1
+  fi
+  local pin
+  if ! pin="$(fetch_server_pin "$host")"; then
+    print_danger "Could not retrieve certificate from %s\n" "$host"
+    return 1
+  fi
+  local tmp="${PROFILES_FILE}.tmp"
+  if [ -n "$(xmlstarlet sel -t -m "//VPN[name=${name_lit}]/serverCertificate" -o yes "${PROFILES_FILE}" 2>/dev/null)" ]; then
+    xmlstarlet ed -u "//VPN[name=${name_lit}]/serverCertificate" -v "$pin" "${PROFILES_FILE}" > "${tmp}"
+  else
+    xmlstarlet ed -s "//VPN[name=${name_lit}]" -t elem -n serverCertificate -v "$pin" "${PROFILES_FILE}" > "${tmp}"
+  fi
+  mv "${tmp}" "${PROFILES_FILE}"
+  chmod 600 "${PROFILES_FILE}" 2>/dev/null || true
+  print_success "Saved %s to profile '%s'.\n" "$pin" "$profile"
+  if verify_gateway_cert "$host"; then
+    print_primary "Certificate also validates against the system trust store.\n"
+  else
+    print_warning "Certificate does NOT chain-validate; verify this pin out-of-band with your VPN administrator.\n"
+  fi
+}
+
 print_pin_instructions() {
   local host="$1"
   print_warning "To pin this gateway's certificate, run:\n"

--- a/profiles.sh
+++ b/profiles.sh
@@ -85,6 +85,24 @@ list_profile_names() {
   printf "%s\n" "${vpn_names[@]}"
 }
 
+profile_exists() {
+  local name_lit; name_lit="$(xpath_literal "$1")"
+  [ -n "$(xmlstarlet sel -t -m "//VPN[name=${name_lit}]" -v name "$PROFILES_FILE" 2>/dev/null)" ]
+}
+
+# Tabular overview of all profiles (no secrets shown).
+list_profiles() {
+  check_file_existence "$PROFILES_FILE" "Profiles"
+  xmlstarlet sel -t -m '//VPN' \
+      -v name -o $'\t' \
+      -v protocol -o $'\t' \
+      -v host -o $'\t' \
+      -v 'duo2FAMethod | duoMethod' -n "$PROFILES_FILE" \
+    | awk -F'\t' '
+        BEGIN { printf "%-25s %-11s %-35s %s\n", "NAME", "PROTOCOL", "HOST", "2FA" }
+        { printf "%-25s %-11s %-35s %s\n", $1, ($2==""?"-":$2), ($3==""?"-":$3), ($4==""?"-":$4) }'
+}
+
 # shellcheck disable=SC2034  # description vars are consumed by core.sh
 set_protocol_description() {
   case $PROTOCOL in

--- a/tests/network.bats
+++ b/tests/network.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# Tests for pin_save (network calls stubbed).
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>With Cert</name><protocol>anyconnect</protocol><host>a.example.com</host><serverCertificate>old-pin</serverCertificate></VPN>
+  <VPN><name>Without Cert</name><protocol>gp</protocol><host>b.example.com</host></VPN>
+  <VPN><name>No Host</name><protocol>gp</protocol><host></host></VPN>
+</VPNs>
+XML
+  print_warning() { :; }
+  print_danger() { :; }
+  print_primary() { :; }
+  print_success() { :; }
+  check_file_existence() { :; }
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../network.sh"
+  # stub the network
+  fetch_server_pin() { echo "pin-sha256:STUBBED="; }
+  verify_gateway_cert() { return 0; }
+}
+
+@test "pin_save updates an existing serverCertificate element" {
+  pin_save "With Cert"
+  run xmlstarlet sel -t -m "//VPN[name='With Cert']" -v serverCertificate "$PROFILES_FILE"
+  [ "$output" = "pin-sha256:STUBBED=" ]
+}
+
+@test "pin_save creates serverCertificate when missing" {
+  pin_save "Without Cert"
+  run xmlstarlet sel -t -m "//VPN[name='Without Cert']" -v serverCertificate "$PROFILES_FILE"
+  [ "$output" = "pin-sha256:STUBBED=" ]
+}
+
+@test "pin_save leaves other profiles untouched" {
+  pin_save "Without Cert"
+  run xmlstarlet sel -t -m "//VPN[name='With Cert']" -v serverCertificate "$PROFILES_FILE"
+  [ "$output" = "old-pin" ]
+}
+
+@test "pin_save fails on unknown profile and on missing host" {
+  run pin_save "Ghost"
+  [ "$status" -ne 0 ]
+  run pin_save "No Host"
+  [ "$status" -ne 0 ]
+}

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -65,3 +65,19 @@ XML
   [ "${lines[1]}" = "Other VPN" ]
   [ "${lines[2]}" = "Quit" ]
 }
+
+@test "profile_exists: true for real profiles (incl. quotes), false otherwise" {
+  profile_exists "Test's VPN"
+  profile_exists "Other VPN"
+  run profile_exists "Ghost VPN"
+  [ "$status" -ne 0 ]
+}
+
+@test "list_profiles prints a header and one row per profile" {
+  check_file_existence() { :; }
+  run list_profiles
+  [[ "${lines[0]}" == NAME* ]]
+  [[ "${lines[1]}" == "Test's VPN"* ]]
+  [[ "${lines[2]}" == "Other VPN"* ]]
+  [ "${#lines[@]}" -eq 3 ]
+}

--- a/vpn-up.command
+++ b/vpn-up.command
@@ -55,29 +55,35 @@ cat <<EOF
 Usage: $PROGRAM_NAME <command>
 
 Commands:
-  start          Start VPN (interactive profile selection)
-  stop           Stop VPN
-  status         Show VPN status
-  restart        Restart VPN (stop+start)
-  setup          Run setup wizard (regenerate config)
-  set-secret     Save a secret field for a profile (e.g., password)
-  delete-secret  Delete a stored secret for a profile
-  pin            Print the pin-sha256 value for a gateway's certificate
-  doctor         Diagnose environment and secret backend
+  start [profile]      Start VPN (interactive menu, or directly by profile name)
+  stop                 Stop VPN
+  status               Show VPN status (profile, gateway, uptime)
+  restart [profile]    Restart VPN (stop+start)
+  list                 List configured VPN profiles
+  logs [-f]            Show the connection log (-f to follow)
+  setup                Run setup wizard (regenerate config)
+  set-secret           Save a secret field for a profile (e.g., password)
+  delete-secret        Delete a stored secret for a profile
+  pin <host[:port]>    Print the pin-sha256 value for a gateway's certificate
+  pin --save <profile> Fetch the pin and write it into the profile
+  doctor               Diagnose environment and secret backend
 
 Examples:
-  $PROGRAM_NAME start
-  $PROGRAM_NAME set-secret WorkVPN password
+  $PROGRAM_NAME start "Work VPN"
+  $PROGRAM_NAME set-secret "Work VPN" password
   $PROGRAM_NAME pin vpn.example.com
-  $PROGRAM_NAME doctor
+  $PROGRAM_NAME pin --save "Work VPN"
+  $PROGRAM_NAME logs -f
 EOF
 }
 
 case "${1:-}" in
-  start)      check_dependencies; start ;;
+  start)      check_dependencies; start "${2:-}" ;;
   stop)       stop ;;
   status)     status ;;
-  restart)    "$0" stop; "$0" start ;;
+  restart)    "$0" stop; "$0" start "${2:-}" ;;
+  list)       list_profiles ;;
+  logs)       show_logs "${2:-}" ;;
   setup)      setup_wizard ;;
   set-secret) shift; profile="${1:-}"; field="${2:-}"; { [ -z "$profile" ] || [ -z "$field" ]; } && { echo "Usage: $0 set-secret <profile> <field>"; exit 1; }
               [ "$field" = "sudo_password" ] && { echo "Storing the sudo password is not supported (it would defeat sudo's protection). See the sudoers rule in the README." >&2; exit 1; }
@@ -85,7 +91,12 @@ case "${1:-}" in
               secrets_set "${profile}" "${field}" "${value}"; echo "Saved secret for ${profile}.${field}." ;;
   delete-secret) shift; profile="${1:-}"; field="${2:-}"; { [ -z "$profile" ] || [ -z "$field" ]; } && { echo "Usage: $0 delete-secret <profile> <field>"; exit 1; }
                  secrets_delete "${profile}" "${field}"; echo "Deleted secret for ${profile}.${field} (if existed)." ;;
-  pin)        shift; host="${1:-}"; [ -z "$host" ] && { echo "Usage: $0 pin <host[:port]>"; exit 1; }
+  pin)        shift
+              if [ "${1:-}" = "--save" ]; then
+                profile="${2:-}"; [ -z "$profile" ] && { echo "Usage: $0 pin --save <profile>"; exit 1; }
+                pin_save "$profile"; exit $?
+              fi
+              host="${1:-}"; [ -z "$host" ] && { echo "Usage: $0 pin <host[:port]> | pin --save <profile>"; exit 1; }
               if pin_value="$(fetch_server_pin "$host")"; then
                 echo "$pin_value"
                 if verify_gateway_cert "$host"; then


### PR DESCRIPTION
## Added
- `start [profile]` / `restart [profile]` — non-interactive connection by profile name.
- `list` — tabular profile overview (no secrets).
- `logs [-f]` — view or follow the connection log.
- `pin --save <profile>` — write the fetched `pin-sha256` into the profile.
- Richer `status`: profile, gateway, connect time, uptime (state file written at connect, removed on stop).

## Changed
- `duo2FAMethod=passcode` prompts for the one-time code at connect time.

18 bats tests passing, shellcheck clean. `pin --save` verified end-to-end against a live gateway in a sandboxed `VPN_UP_HOME`.