### PR TITLE
v3.3.0: add-profile wizard, shell completion, per-profile state files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.3.0] — 2026-06-12
+### Profiles & Completion Update
+
+### Added
+- `add-profile` — guided profile creation: validates inputs, appends a
+  well-formed `<VPN>` block, and optionally stores the password in the
+  secrets backend and saves the gateway's certificate pin in one flow.
+- Bash/zsh tab completion (`completions/vpn-up.bash`) for commands and
+  profile names, including names with spaces.
+- Per-profile PID, state, and log files — `status` reports every running
+  connection, `stop [profile]` and `logs [-f] [profile]` target a specific
+  one, and `logs` with no argument shows the most recent log.
+
+### Changed
+- Stale PID/state files are cleaned up automatically during `status`.
+- One-connection-at-a-time policy is kept: `start` refuses while any VPN is
+  running (the per-profile files make the bookkeeping accurate, not the
+  tunnels concurrent).
+
+---
+
 ## [v3.2.0] — 2026-06-12
 ### Scriptability & CLI Update
 

--- a/README.md
+++ b/README.md
@@ -189,10 +189,25 @@ readonly ENCRYPTION_ENABLED=TRUE
 ./vpn-up.command start                  # interactive profile menu
 ./vpn-up.command start "Frankfurt VPN"  # connect directly (scriptable)
 ./vpn-up.command list                   # list configured profiles
+./vpn-up.command add-profile            # guided profile creation (+ secret, + pin)
 ./vpn-up.command status                 # profile, gateway, uptime
 ./vpn-up.command logs -f                # follow the connection log
-./vpn-up.command stop
+./vpn-up.command stop                   # stop the VPN (or: stop "Frankfurt VPN")
 ```
+
+Each profile keeps its own log and PID/state files under `~/.config/vpn-up`,
+so `status`, `stop`, and `logs` are profile-aware.
+
+### Shell completion
+```bash
+# bash (~/.bashrc)
+source /path/to/vpn-up-for-openconnect/completions/vpn-up.bash
+
+# zsh (~/.zshrc)
+autoload -U +X bashcompinit && bashcompinit
+source /path/to/vpn-up-for-openconnect/completions/vpn-up.bash
+```
+Completes commands and profile names (spaces handled).
 
 ### Secrets Management
 ```bash

--- a/completions/vpn-up.bash
+++ b/completions/vpn-up.bash
@@ -1,0 +1,57 @@
+# bash completion for vpn-up.command
+# bash:  source /path/to/completions/vpn-up.bash   (e.g. from ~/.bashrc)
+# zsh :  autoload -U +X bashcompinit && bashcompinit
+#        source /path/to/completions/vpn-up.bash
+
+_vpn_up_complete_profiles() {
+  local cur="$1" line
+  cur="${cur//\\ / }"   # un-escape spaces the shell already escaped
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      "$cur"*) COMPREPLY+=("${line// /\\ }") ;;
+    esac
+  done < <("${COMP_WORDS[0]}" list-names 2>/dev/null)
+}
+
+_vpn_up() {
+  local cur prev cmd
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  cmd="${COMP_WORDS[1]:-}"
+
+  if [ "$COMP_CWORD" -eq 1 ]; then
+    mapfile -t COMPREPLY < <(compgen -W "start stop status restart list logs setup add-profile set-secret delete-secret pin doctor" -- "$cur")
+    return
+  fi
+
+  case "$cmd" in
+    start|restart|stop)
+      [ "$COMP_CWORD" -eq 2 ] && _vpn_up_complete_profiles "$cur"
+      ;;
+    set-secret|delete-secret)
+      if [ "$COMP_CWORD" -eq 2 ]; then
+        _vpn_up_complete_profiles "$cur"
+      elif [ "$COMP_CWORD" -eq 3 ]; then
+        mapfile -t COMPREPLY < <(compgen -W "password" -- "$cur")
+      fi
+      ;;
+    logs)
+      if [ "$cur" = "-" ] || [ "$cur" = "-f" ]; then
+        COMPREPLY=("-f")
+      else
+        _vpn_up_complete_profiles "$cur"
+      fi
+      ;;
+    pin)
+      if [ "$COMP_CWORD" -eq 2 ]; then
+        mapfile -t COMPREPLY < <(compgen -W "--save" -- "$cur")
+      elif [ "$prev" = "--save" ]; then
+        _vpn_up_complete_profiles "$cur"
+      fi
+      ;;
+  esac
+}
+
+complete -F _vpn_up vpn-up.command ./vpn-up.command vpn-up

--- a/core.sh
+++ b/core.sh
@@ -44,14 +44,12 @@ start() {
     exit 1
   fi
 
-  if is_vpn_running; then
-    print_warning "Already connected to a VPN!\n"
+  if any_vpn_running; then
+    print_warning "Already connected to a VPN! Run '%s status' or '%s stop' first.\n" "${PROGRAM_NAME}" "${PROGRAM_NAME}"
     exit 1
   fi
 
   print_primary "Starting ${PROGRAM_NAME} ...\n"
-  print_warning "Process ID (PID) stored in %s ...\n" "${PID_FILE_PATH}"
-  print_warning "Logs file (LOG) stored in %s ...\n" "${LOG_FILE_PATH}"
 
   if [ -n "$requested" ]; then
     # Non-interactive: profile named on the command line
@@ -111,6 +109,11 @@ connect() {
     return 1
   fi
 
+  # Each profile gets its own PID/state/log files
+  set_profile_paths "${VPN_NAME}"
+  print_warning "Process ID (PID) stored in %s ...\n" "${PID_FILE_PATH}"
+  print_warning "Logs file (LOG) stored in %s ...\n" "${LOG_FILE_PATH}"
+
   # Duo passcodes are one-time values; never read them from the XML —
   # prompt at connect time instead.
   if [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
@@ -149,34 +152,47 @@ connect() {
   run_openconnect
 }
 
+_print_state_details() {
+  local statefile="$1" pid="$2"
+  if [ -f "$statefile" ]; then
+    local profile host connected_at
+    profile="$(awk -F= '$1=="profile"{print substr($0,9); exit}' "$statefile")"
+    host="$(awk -F= '$1=="host"{print substr($0,6); exit}' "$statefile")"
+    connected_at="$(awk -F= '$1=="connected_at"{print substr($0,14); exit}' "$statefile")"
+    print_primary "  Profile : %s\n" "${profile:-unknown}"
+    print_primary "  Gateway : %s\n" "${host:-unknown}"
+    print_primary "  Since   : %s\n" "${connected_at:-unknown}"
+  fi
+  print_primary "  Uptime  : %s\n" "$(ps -p "$pid" -o etime= 2>/dev/null | tr -d ' ' || echo unknown)"
+}
+
 status() {
-  if is_vpn_running; then
-    local pid; pid="$(cat "$PID_FILE_PATH")"
-    print_success "VPN is running (PID: %s)\n" "$pid"
-    if [ -f "$STATE_FILE_PATH" ]; then
-      local profile host connected_at
-      profile="$(awk -F= '$1=="profile"{print substr($0,9); exit}' "$STATE_FILE_PATH")"
-      host="$(awk -F= '$1=="host"{print substr($0,6); exit}' "$STATE_FILE_PATH")"
-      connected_at="$(awk -F= '$1=="connected_at"{print substr($0,14); exit}' "$STATE_FILE_PATH")"
-      print_primary "  Profile : %s\n" "${profile:-unknown}"
-      print_primary "  Gateway : %s\n" "${host:-unknown}"
-      print_primary "  Since   : %s\n" "${connected_at:-unknown}"
+  local found=0 f pid statefile
+  for f in "${DATA_DIR}/pids/"*.pid; do
+    [ -e "$f" ] || continue
+    pid="$(cat "$f")"
+    statefile="${f%.pid}.state"
+    if is_openconnect_pid "$pid"; then
+      found=1
+      print_success "VPN is running (PID: %s)\n" "$pid"
+      _print_state_details "$statefile" "$pid"
+    else
+      rm -f "$f" "$statefile"
     fi
-    print_primary "  Uptime  : %s\n" "$(ps -p "$pid" -o etime= 2>/dev/null | tr -d ' ' || echo unknown)"
-  else
+  done
+  if [ "$found" -eq 0 ]; then
     print_warning "VPN is not running.\n"
   fi
 }
 
-stop() {
-  if [ ! -f "$PID_FILE_PATH" ]; then
-    print_warning "VPN is not running.\n"
-    return 0
-  fi
-  local pid; pid="$(cat "$PID_FILE_PATH")"
+# Stop the connection recorded in one PID file.
+_stop_by_pid_file() {
+  local pidfile="$1"
+  local statefile="${pidfile%.pid}.state"
+  local pid; pid="$(cat "$pidfile")"
   if ! is_openconnect_pid "$pid"; then
     print_warning "Stale PID file (no openconnect process with PID %s); cleaning up.\n" "$pid"
-    rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
+    rm -f "$pidfile" "$statefile"
     return 0
   fi
   # openconnect runs as root, so killing it needs sudo too.
@@ -198,8 +214,34 @@ stop() {
     print_danger "Could not stop openconnect (PID: %s); VPN may still be up!\n" "$pid"
     return 1
   fi
-  rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
+  rm -f "$pidfile" "$statefile"
   print_success "VPN stopped.\n"
+}
+
+stop() {
+  local requested="${1:-}" f
+  local files=()
+  if [ -n "$requested" ]; then
+    f="${DATA_DIR}/pids/${PROGRAM_NAME}.$(profile_slug "$requested").pid"
+    if [ ! -f "$f" ]; then
+      print_warning "VPN profile '%s' is not running.\n" "$requested"
+      return 0
+    fi
+    files=("$f")
+  else
+    for f in "${DATA_DIR}/pids/"*.pid; do
+      [ -e "$f" ] && files+=("$f")
+    done
+    if [ "${#files[@]}" -eq 0 ]; then
+      print_warning "VPN is not running.\n"
+      return 0
+    fi
+  fi
+  local rc=0
+  for f in "${files[@]}"; do
+    _stop_by_pid_file "$f" || rc=1
+  done
+  return "$rc"
 }
 
 run_openconnect() {

--- a/logging.sh
+++ b/logging.sh
@@ -1,20 +1,60 @@
 # logging.sh - simple logging helpers
 
+# Legacy single-connection paths; start() switches these to per-profile
+# paths via set_profile_paths once a profile is selected.
 PID_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.pid"
 # shellcheck disable=SC2034  # used by core.sh
 LOG_FILE_PATH="${DATA_DIR}/logs/${PROGRAM_NAME}.log"
 # shellcheck disable=SC2034  # used by core.sh
 STATE_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.state"
 
+# Filesystem-safe slug for a profile name (spaces etc. become '_').
+profile_slug() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+
+# Point the PID/LOG/STATE globals at a specific profile's files.
+# shellcheck disable=SC2034  # globals are consumed by core.sh
+set_profile_paths() {
+  local slug; slug="$(profile_slug "$1")"
+  PID_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.pid"
+  STATE_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.state"
+  LOG_FILE_PATH="${DATA_DIR}/logs/${PROGRAM_NAME}.${slug}.log"
+}
+
+# True if any PID file (legacy or per-profile) points at a live openconnect.
+any_vpn_running() {
+  local f
+  for f in "${DATA_DIR}/pids/"*.pid; do
+    [ -e "$f" ] || continue
+    is_openconnect_pid "$(cat "$f")" && return 0
+  done
+  return 1
+}
+
 show_logs() {
-  if [ ! -f "$LOG_FILE_PATH" ]; then
-    print_warning "No log file yet at %s\n" "$LOG_FILE_PATH"
+  local follow="" profile="" a file
+  for a in "$@"; do
+    case "$a" in
+      -f) follow=1 ;;
+      "") : ;;
+      *)  profile="$a" ;;
+    esac
+  done
+  if [ -n "$profile" ]; then
+    file="${DATA_DIR}/logs/${PROGRAM_NAME}.$(profile_slug "$profile").log"
+  else
+    # most recently modified log, falling back to the legacy path
+    # shellcheck disable=SC2012  # filenames are program-generated slugs (no newlines)
+    file="$(ls -t "${DATA_DIR}/logs/"*.log 2>/dev/null | head -1)"
+    [ -n "$file" ] || file="$LOG_FILE_PATH"
+  fi
+  if [ ! -f "$file" ]; then
+    print_warning "No log file yet at %s\n" "$file"
     return 0
   fi
-  if [ "${1:-}" = "-f" ]; then
-    tail -f "$LOG_FILE_PATH"
+  if [ -n "$follow" ]; then
+    tail -f "$file"
   else
-    tail -n 50 "$LOG_FILE_PATH"
+    tail -n 50 "$file"
   fi
 }
 

--- a/profiles.sh
+++ b/profiles.sh
@@ -85,6 +85,12 @@ list_profile_names() {
   printf "%s\n" "${vpn_names[@]}"
 }
 
+# Bare profile names, one per line (machine-readable; used by completion).
+profile_names_raw() {
+  [ -f "$PROFILES_FILE" ] || return 0
+  xmlstarlet sel -t -m '//VPN' -v name -n "$PROFILES_FILE" 2>/dev/null
+}
+
 profile_exists() {
   local name_lit; name_lit="$(xpath_literal "$1")"
   [ -n "$(xmlstarlet sel -t -m "//VPN[name=${name_lit}]" -v name "$PROFILES_FILE" 2>/dev/null)" ]

--- a/setup.sh
+++ b/setup.sh
@@ -57,6 +57,67 @@ CFG
   print_success "Saved configuration to %s\n" "${CONFIGURATION_FILE}"
 }
 
+# Append a <VPN> block to the profiles file (password stays empty — secrets
+# belong in the secrets backend, set separately).
+append_profile() {
+  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6"
+  local tmp="${PROFILES_FILE}.tmp"
+  xmlstarlet ed \
+    -s '/VPNs' -t elem -n VPN -v '' \
+    -s '/VPNs/VPN[last()]' -t elem -n name -v "$name" \
+    -s '/VPNs/VPN[last()]' -t elem -n protocol -v "$proto" \
+    -s '/VPNs/VPN[last()]' -t elem -n host -v "$host" \
+    -s '/VPNs/VPN[last()]' -t elem -n authGroup -v "$group" \
+    -s '/VPNs/VPN[last()]' -t elem -n user -v "$user" \
+    -s '/VPNs/VPN[last()]' -t elem -n password -v '' \
+    -s '/VPNs/VPN[last()]' -t elem -n duo2FAMethod -v "$duo" \
+    -s '/VPNs/VPN[last()]' -t elem -n serverCertificate -v '' \
+    "${PROFILES_FILE}" > "${tmp}" && mv "${tmp}" "${PROFILES_FILE}" && chmod 600 "${PROFILES_FILE}"
+}
+
+add_profile_wizard() {
+  if [ ! -f "$PROFILES_FILE" ]; then
+    ( umask 077; printf '<VPNs>\n</VPNs>\n' > "$PROFILES_FILE" )
+  fi
+
+  local name proto host group user duo
+  read -r -p "Profile name: " name
+  [ -n "$name" ] || { print_danger "Profile name is required.\n"; return 1; }
+  if profile_exists "$name"; then
+    print_danger "Profile '%s' already exists.\n" "$name"
+    return 1
+  fi
+
+  read -r -p "Protocol (anyconnect/nc/gp/pulse) [anyconnect]: " proto
+  proto="${proto:-anyconnect}"
+  case "$proto" in
+    anyconnect|nc|gp|pulse) : ;;
+    *) print_danger "Unknown protocol '%s'.\n" "$proto"; return 1 ;;
+  esac
+
+  read -r -p "Gateway host[:port]: " host
+  [ -n "$host" ] || { print_danger "Gateway host is required.\n"; return 1; }
+  read -r -p "Auth group (optional): " group
+  read -r -p "Username: " user
+  read -r -p "Duo 2FA method (push/phone/sms/passcode; empty = gateway default): " duo
+
+  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" \
+    || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
+  print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
+
+  read -r -p "Store the VPN password now? (TRUE/FALSE) [TRUE]: " _in_pw
+  if [ "$(_bool_default "${_in_pw}" "TRUE")" = TRUE ]; then
+    local _p
+    read -r -s -p "Enter password for ${user}@${host}: " _p; echo
+    [ -n "$_p" ] && secrets_set "$name" "password" "$_p" && print_success "Password stored securely.\n"
+  fi
+
+  read -r -p "Fetch and save the gateway certificate pin now? (TRUE/FALSE) [TRUE]: " _in_pin
+  if [ "$(_bool_default "${_in_pin}" "TRUE")" = TRUE ]; then
+    pin_save "$name" || print_warning "Pin not saved; you can retry later with: %s pin --save '%s'\n" "${PROGRAM_NAME}" "$name"
+  fi
+}
+
 setup_wizard() {
   printf "%b\n" "${PRIMARY}Running first-time setup...${RESET}"
 

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -73,6 +73,36 @@ XML
   [ "$status" -ne 0 ]
 }
 
+@test "profile_names_raw lists bare names without Quit" {
+  run profile_names_raw
+  [ "${lines[0]}" = "Test's VPN" ]
+  [ "${lines[1]}" = "Other VPN" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "append_profile adds a well-formed selectable profile" {
+  print_success() { :; }
+  _bool_default() { echo FALSE; }
+  source "$BATS_TEST_DIRNAME/../setup.sh"
+  append_profile "Berlin VPN" gp "berlin.example.com:8443" Staff sorin push
+  xmlstarlet val -q "$PROFILES_FILE"
+  profile_exists "Berlin VPN"
+  load_profile_fields "Berlin VPN"
+  [ "$PROTOCOL" = "gp" ]
+  [ "$VPN_HOST" = "berlin.example.com:8443" ]
+  [ "$VPN_GROUP" = "Staff" ]
+  [ "$VPN_USER" = "sorin" ]
+  [ "$VPN_PASSWD" = "" ]
+  [ "$VPN_DUO2FAMETHOD" = "push" ]
+}
+
+@test "profile_slug produces filesystem-safe names" {
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  [ "$(profile_slug "Frankfurt VPN")" = "Frankfurt_VPN" ]
+  [ "$(profile_slug "a/b:c d")" = "a_b_c_d" ]
+  [ "$(profile_slug "safe-name_1.2")" = "safe-name_1.2" ]
+}
+
 @test "list_profiles prints a header and one row per profile" {
   check_file_existence() { :; }
   run list_profiles

--- a/vpn-up.command
+++ b/vpn-up.command
@@ -56,12 +56,13 @@ Usage: $PROGRAM_NAME <command>
 
 Commands:
   start [profile]      Start VPN (interactive menu, or directly by profile name)
-  stop                 Stop VPN
+  stop [profile]       Stop VPN (all running, or one profile)
   status               Show VPN status (profile, gateway, uptime)
   restart [profile]    Restart VPN (stop+start)
   list                 List configured VPN profiles
-  logs [-f]            Show the connection log (-f to follow)
+  logs [-f] [profile]  Show the connection log (-f to follow)
   setup                Run setup wizard (regenerate config)
+  add-profile          Add a VPN profile interactively (incl. secret + pin)
   set-secret           Save a secret field for a profile (e.g., password)
   delete-secret        Delete a stored secret for a profile
   pin <host[:port]>    Print the pin-sha256 value for a gateway's certificate
@@ -79,12 +80,14 @@ EOF
 
 case "${1:-}" in
   start)      check_dependencies; start "${2:-}" ;;
-  stop)       stop ;;
+  stop)       stop "${2:-}" ;;
   status)     status ;;
-  restart)    "$0" stop; "$0" start "${2:-}" ;;
+  restart)    "$0" stop "${2:-}"; "$0" start "${2:-}" ;;
   list)       list_profiles ;;
-  logs)       show_logs "${2:-}" ;;
+  list-names) profile_names_raw ;;
+  logs)       shift; show_logs "$@" ;;
   setup)      setup_wizard ;;
+  add-profile) add_profile_wizard ;;
   set-secret) shift; profile="${1:-}"; field="${2:-}"; { [ -z "$profile" ] || [ -z "$field" ]; } && { echo "Usage: $0 set-secret <profile> <field>"; exit 1; }
               [ "$field" = "sudo_password" ] && { echo "Storing the sudo password is not supported (it would defeat sudo's protection). See the sudoers rule in the README." >&2; exit 1; }
               read -r -s -p "Enter value for ${profile}.${field}: " value; echo


### PR DESCRIPTION
## Added
- `add-profile` — guided profile creation with validation, optional secret storage, and certificate pin fetch in one flow.
- Bash/zsh tab completion for commands and profile names (space-safe).
- Per-profile PID/state/log files: `status` reports every running connection and cleans stale files; `stop [profile]` and `logs [-f] [profile]` target a specific profile; `logs` defaults to the most recent log.

## Notes
- One-connection-at-a-time policy kept; legacy single-path files handled by the same scan.
- 21 bats tests passing, shellcheck clean (incl. the completion script).