### PR TITLE
v3.4.0: login-service mode with auto-reconnect, desktop notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.4.0] — 2026-06-12
+### Service & Notifications Update
+
+### Added
+- `service install|uninstall|status` — run a profile as a login service with
+  auto-reconnect: launchd user agent on macOS, systemd user unit on Linux.
+  The service manager supervises openconnect in the foreground and restarts
+  it if the tunnel drops (30s throttle). Preflight checks catch missing
+  passwordless sudo, missing stored password, and passcode-2FA profiles.
+- Desktop notifications on connect/disconnect/failure (macOS Notification
+  Center via osascript, Linux via notify-send); new `NOTIFICATIONS` setting
+  (default `TRUE`), prompted in setup and shown by `doctor`.
+- Foreground sessions now record their own PID/state (openconnect only
+  writes `--pid-file` when daemonizing), so `status` and `stop` work during
+  foreground and service sessions too.
+
+### Changed
+- Service mode (`VPN_UP_SERVICE=1`) fails fast with clear errors instead of
+  prompting: non-interactive `sudo -n`, stored-secret requirement, and a
+  passcode-2FA guard.
+
+---
+
 ## [v3.3.0] — 2026-06-12
 ### Profiles & Completion Update
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ automatically on first run.
 readonly QUIET=TRUE          # openconnect output verbosity
 readonly BACKGROUND=TRUE
 readonly SHOW_BANNER=TRUE    # ASCII banner on start (independent of QUIET)
+readonly NOTIFICATIONS=TRUE  # desktop notification on connect/disconnect
 readonly ENCRYPTION_ENABLED=TRUE
 ```
 
@@ -197,6 +198,23 @@ readonly ENCRYPTION_ENABLED=TRUE
 
 Each profile keeps its own log and PID/state files under `~/.config/vpn-up`,
 so `status`, `stop`, and `logs` are profile-aware.
+
+### Run as a login service (auto-reconnect)
+```bash
+./vpn-up.command service install "Frankfurt VPN"    # connect at login, reconnect on drop
+./vpn-up.command service status
+./vpn-up.command service uninstall "Frankfurt VPN"
+```
+Uses a launchd user agent on macOS and a systemd user unit on Linux; the
+service manager supervises openconnect in the foreground and relaunches it
+if the tunnel drops (30s throttle). Requirements:
+- the passwordless sudoers rule for openconnect (see above) — there is no TTY
+  to type a sudo password into
+- the profile's password stored in the secrets backend
+- a non-interactive 2FA method (`push`, `phone`, `sms` — not `passcode`)
+
+Desktop notifications fire on connect/disconnect (macOS Notification Center /
+`notify-send`); disable with `NOTIFICATIONS=FALSE` in the config.
 
 ### Shell completion
 ```bash

--- a/completions/vpn-up.bash
+++ b/completions/vpn-up.bash
@@ -22,11 +22,18 @@ _vpn_up() {
   cmd="${COMP_WORDS[1]:-}"
 
   if [ "$COMP_CWORD" -eq 1 ]; then
-    mapfile -t COMPREPLY < <(compgen -W "start stop status restart list logs setup add-profile set-secret delete-secret pin doctor" -- "$cur")
+    mapfile -t COMPREPLY < <(compgen -W "start stop status restart list logs setup add-profile service set-secret delete-secret pin doctor" -- "$cur")
     return
   fi
 
   case "$cmd" in
+    service)
+      if [ "$COMP_CWORD" -eq 2 ]; then
+        mapfile -t COMPREPLY < <(compgen -W "install uninstall status" -- "$cur")
+      elif [ "$COMP_CWORD" -eq 3 ] && { [ "$prev" = "install" ] || [ "$prev" = "uninstall" ]; }; then
+        _vpn_up_complete_profiles "$cur"
+      fi
+      ;;
     start|restart|stop)
       [ "$COMP_CWORD" -eq 2 ] && _vpn_up_complete_profiles "$cur"
       ;;

--- a/core.sh
+++ b/core.sh
@@ -16,15 +16,22 @@ assert_safe_to_source() {
   fi
 }
 
+# Source the config (executable shell) after the safety checks. Safe to call
+# from any command; no-op when the config doesn't exist yet.
+load_config() {
+  [ -f "$CONFIGURATION_FILE" ] || return 0
+  assert_safe_to_source "$CONFIGURATION_FILE" || exit 1
+  # shellcheck disable=SC1090
+  source "$CONFIGURATION_FILE"
+}
+
 start() {
   local requested="${1:-}"
   # Ensure config exists or run wizard
   if [ ! -f "$CONFIGURATION_FILE" ]; then
     setup_wizard
   fi
-  assert_safe_to_source "$CONFIGURATION_FILE" || exit 1
-  # shellcheck disable=SC1090
-  source "$CONFIGURATION_FILE"
+  load_config
   print_warning "Loaded configuration from %s ...\n" "$CONFIGURATION_FILE"
 
   # Seed the profiles template on first run, then ask the user to fill it in.
@@ -59,7 +66,7 @@ start() {
       exit 1
     fi
     load_profile_fields "$requested"
-    migrate_or_fetch_password
+    migrate_or_fetch_password || exit 1
     connect
   else
     # Interactive profile selection (modern Bash mapfile)
@@ -72,7 +79,7 @@ start() {
       fi
       if printf "%s\n" "${vpn_names[@]}" | grep -qx -- "$option"; then
         load_profile_fields "$option"
-        migrate_or_fetch_password
+        migrate_or_fetch_password || exit 1
         connect
         break
       else
@@ -81,13 +88,20 @@ start() {
     done
   fi
 
-  if is_vpn_running; then
-    write_connection_state
-    print_success "Connected to %s\n" "${VPN_NAME}"
-    print_current_ip_address
-  else
-    print_danger "Failed to connect! Last log lines from %s:\n" "${LOG_FILE_PATH}"
-    tail -n 15 "$LOG_FILE_PATH" 2>/dev/null || true
+  # In foreground/service mode run_openconnect blocks for the whole session
+  # and cleans up after itself; the post-connect check only makes sense when
+  # openconnect daemonized.
+  if [ -z "${VPN_UP_SERVICE:-}" ] && [ "${BACKGROUND:-FALSE}" = TRUE ]; then
+    if is_vpn_running; then
+      write_connection_state
+      print_success "Connected to %s\n" "${VPN_NAME}"
+      notify "VPN Up" "Connected to ${VPN_NAME}"
+      print_current_ip_address
+    else
+      print_danger "Failed to connect! Last log lines from %s:\n" "${LOG_FILE_PATH}"
+      tail -n 15 "$LOG_FILE_PATH" 2>/dev/null || true
+      notify "VPN Up" "Failed to connect to ${VPN_NAME:-VPN}"
+    fi
   fi
 }
 
@@ -117,6 +131,10 @@ connect() {
   # Duo passcodes are one-time values; never read them from the XML —
   # prompt at connect time instead.
   if [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
+    if [ -n "${VPN_UP_SERVICE:-}" ]; then
+      print_danger "Profile '%s' uses a Duo passcode, which needs interactive input; it cannot run as a service. Use push/phone/sms instead.\n" "${VPN_NAME}"
+      return 1
+    fi
     read -r -p "Enter Duo passcode for ${VPN_NAME}: " VPN_DUO2FAMETHOD
     if [ -z "$VPN_DUO2FAMETHOD" ]; then
       print_danger "No passcode entered; aborting.\n"
@@ -214,12 +232,16 @@ _stop_by_pid_file() {
     print_danger "Could not stop openconnect (PID: %s); VPN may still be up!\n" "$pid"
     return 1
   fi
+  local profile=""
+  [ -f "$statefile" ] && profile="$(awk -F= '$1=="profile"{print substr($0,9); exit}' "$statefile")"
   rm -f "$pidfile" "$statefile"
   print_success "VPN stopped.\n"
+  notify "VPN Up" "Disconnected from ${profile:-VPN}"
 }
 
 stop() {
   local requested="${1:-}" f
+  load_config
   local files=()
   if [ -n "$requested" ]; then
     f="${DATA_DIR}/pids/${PROGRAM_NAME}.$(profile_slug "$requested").pid"
@@ -248,10 +270,21 @@ run_openconnect() {
   # Validate sudo up-front on the TTY so the prompt doesn't collide with the
   # password pipe below. For passwordless use, configure a scoped sudoers rule
   # (see README) instead of storing the sudo password anywhere.
-  if ! sudo -v; then
+  if [ -n "${VPN_UP_SERVICE:-}" ]; then
+    # Service mode (launchd/systemd): no TTY, so sudo must not prompt.
+    if ! sudo -n -v 2>/dev/null; then
+      print_danger "Service mode requires a passwordless sudoers rule for openconnect (see README).\n"
+      return 1
+    fi
+  elif ! sudo -v; then
     print_danger "sudo authentication failed; cannot start openconnect.\n"
     return 1
   fi
+
+  # Under launchd/systemd the service manager must supervise openconnect
+  # itself, so force foreground; KeepAlive/Restart provides auto-reconnect.
+  local effective_background="${BACKGROUND:-FALSE}"
+  [ -n "${VPN_UP_SERVICE:-}" ] && effective_background=FALSE
 
   # Build argv array (no eval)
   local args=()
@@ -259,7 +292,7 @@ run_openconnect() {
   args+=(--user="$VPN_USER")
   args+=(--passwd-on-stdin)
   [ "${QUIET:-FALSE}" = TRUE ] && args+=(-q)
-  [ "${BACKGROUND:-FALSE}" = TRUE ] && args+=(--background)
+  [ "$effective_background" = TRUE ] && args+=(--background)
   [ -n "$SERVER_CERTIFICATE" ] && args+=(--servercert="$SERVER_CERTIFICATE")
   [ -n "$VPN_GROUP" ] && args+=(--authgroup "$VPN_GROUP")
   args+=("$VPN_HOST")
@@ -276,7 +309,7 @@ run_openconnect() {
   local stdin_lines="$VPN_PASSWD"
   [ -n "$VPN_DUO2FAMETHOD" ] && stdin_lines+=$'\n'"$VPN_DUO2FAMETHOD"
   ( umask 077; : > "$LOG_FILE_PATH" )
-  if [ "${BACKGROUND:-FALSE}" = TRUE ]; then
+  if [ "$effective_background" = TRUE ]; then
     # The daemonized child keeps stdout open, so piping through tee would
     # hang the shell forever after openconnect backgrounds itself; write
     # straight to the log instead.
@@ -284,8 +317,22 @@ run_openconnect() {
     printf "%s\n" "$stdin_lines" \
       | sudo openconnect "${args[@]}" >> "$LOG_FILE_PATH" 2>&1
   else
+    # Foreground: openconnect only writes --pid-file when backgrounding, so
+    # record the PID ourselves (after the tunnel has had time to come up) so
+    # status/stop work during a foreground/service session.
+    write_connection_state
+    ( sleep 3
+      _pid="$(pgrep -n -x openconnect 2>/dev/null || true)"
+      if [ -n "$_pid" ]; then
+        printf '%s\n' "$_pid" > "$PID_FILE_PATH"
+        notify "VPN Up" "Connected to ${VPN_NAME}"
+      fi
+    ) &
     printf "%s\n" "$stdin_lines" \
       | sudo openconnect "${args[@]}" 2>&1 | tee -a "$LOG_FILE_PATH"
+    # Foreground session over (disconnect or failure): clean our records.
+    rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
+    notify "VPN Up" "Disconnected from ${VPN_NAME:-VPN}"
   fi
 
   # Drop the password from shell memory as soon as it has been piped.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -52,7 +52,7 @@ doctor() {
   echo
   echo "Config preview:"
   if [ -f "$CONFIGURATION_FILE" ]; then
-    grep -E '^(readonly (SUDO|BACKGROUND|QUIET|SHOW_BANNER|ENCRYPTION_ENABLED))' "$CONFIGURATION_FILE" || true
+    grep -E '^(readonly (SUDO|BACKGROUND|QUIET|SHOW_BANNER|NOTIFICATIONS|ENCRYPTION_ENABLED))' "$CONFIGURATION_FILE" || true
   else
     echo "  (no config yet; run ./vpn-up.command setup)"
   fi

--- a/profiles.sh
+++ b/profiles.sh
@@ -73,6 +73,10 @@ migrate_or_fetch_password() {
     scrub_profile_password "${VPN_NAME}"
   fi
   if [ -z "$s" ]; then
+    if [ -n "${VPN_UP_SERVICE:-}" ]; then
+      print_danger "No stored password for '%s' and service mode cannot prompt. Store one first: %s set-secret '%s' password\n" "${VPN_NAME}" "${PROGRAM_NAME}" "${VPN_NAME}"
+      return 1
+    fi
     read -r -s -p "Enter password for ${VPN_USER}@${VPN_HOST}: " s; echo
     secrets_set "${VPN_NAME}" "password" "${s}"
   fi

--- a/service.sh
+++ b/service.sh
@@ -1,0 +1,192 @@
+# service.sh - run a profile as a login service with auto-reconnect
+# macOS: launchd user agent (~/Library/LaunchAgents)
+# Linux: systemd user unit (~/.config/systemd/user)
+#
+# Service mode runs openconnect in the FOREGROUND under the service manager;
+# KeepAlive/Restart relaunches it if the tunnel drops. Requirements:
+#   - a passwordless sudoers rule for openconnect (see README)
+#   - the profile's password stored in the secrets backend
+#   - a non-interactive 2FA method (push/phone/sms — not passcode)
+
+LAUNCH_AGENT_DIR="${VPN_UP_LAUNCH_AGENT_DIR:-$HOME/Library/LaunchAgents}"
+SYSTEMD_USER_DIR="${VPN_UP_SYSTEMD_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
+SERVICE_LABEL_PREFIX="com.sorinipate.vpn-up"
+
+_xml_escape() { local s="$1"; s="${s//&/&amp;}"; s="${s//</&lt;}"; s="${s//>/&gt;}"; printf '%s' "$s"; }
+
+_service_path_for() {
+  local slug; slug="$(profile_slug "$1")"
+  if [ "$(uname)" = "Darwin" ]; then
+    printf '%s/%s.%s.plist' "$LAUNCH_AGENT_DIR" "$SERVICE_LABEL_PREFIX" "$slug"
+  else
+    printf '%s/vpn-up-%s.service' "$SYSTEMD_USER_DIR" "$slug"
+  fi
+}
+
+# Generate the launchd plist for a profile to stdout.
+write_launch_agent_plist() {
+  local profile="$1" slug bash_bin oc_dir
+  slug="$(profile_slug "$profile")"
+  bash_bin="${BASH:-$(command -v bash)}"
+  oc_dir="$(dirname "$(command -v openconnect)")"
+  cat <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL_PREFIX}.${slug}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$(_xml_escape "$bash_bin")</string>
+    <string>$(_xml_escape "${PROGRAM_PATH}/${PROGRAM_NAME}")</string>
+    <string>start</string>
+    <string>$(_xml_escape "$profile")</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VPN_UP_SERVICE</key>
+    <string>1</string>
+    <key>PATH</key>
+    <string>$(_xml_escape "$oc_dir"):/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>StandardOutPath</key>
+  <string>$(_xml_escape "${DATA_DIR}/logs/service.${slug}.log")</string>
+  <key>StandardErrorPath</key>
+  <string>$(_xml_escape "${DATA_DIR}/logs/service.${slug}.log")</string>
+</dict>
+</plist>
+PLIST
+}
+
+# Generate the systemd user unit for a profile to stdout.
+write_systemd_unit() {
+  local profile="$1" bash_bin oc_dir
+  bash_bin="${BASH:-$(command -v bash)}"
+  oc_dir="$(dirname "$(command -v openconnect)")"
+  cat <<UNIT
+[Unit]
+Description=VPN Up for OpenConnect (${profile})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${bash_bin} ${PROGRAM_PATH}/${PROGRAM_NAME} start "${profile}"
+Environment=VPN_UP_SERVICE=1
+Environment=PATH=${oc_dir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+UNIT
+}
+
+# Sanity checks before installing a service for a profile.
+_service_preflight() {
+  local profile="$1"
+  if ! profile_exists "$profile"; then
+    print_danger "Unknown profile '%s'.\n" "$profile"
+    return 1
+  fi
+  if ! sudo -n -v 2>/dev/null; then
+    print_warning "No passwordless sudo detected. Service mode requires a sudoers rule for openconnect (see README); the service will fail until it exists.\n"
+  fi
+  if [ -z "$(secrets_get "$profile" "password" 2>/dev/null)" ]; then
+    print_warning "No stored password for '%s'. Store one first: %s set-secret '%s' password\n" "$profile" "${PROGRAM_NAME}" "$profile"
+  fi
+  local duo
+  duo="$(xmlstarlet sel -t -m "//VPN[name=$(xpath_literal "$profile")]" -v 'duo2FAMethod | duoMethod' "$PROFILES_FILE" 2>/dev/null)"
+  if [ "$duo" = "passcode" ]; then
+    print_danger "Profile '%s' uses a Duo passcode (interactive); it cannot run as a service.\n" "$profile"
+    return 1
+  fi
+  return 0
+}
+
+service_install() {
+  local profile="$1"
+  [ -n "$profile" ] || { echo "Usage: ${PROGRAM_NAME} service install <profile>" >&2; return 1; }
+  _service_preflight "$profile" || return 1
+  local target; target="$(_service_path_for "$profile")"
+  if [ "$(uname)" = "Darwin" ]; then
+    mkdir -p "$LAUNCH_AGENT_DIR"
+    write_launch_agent_plist "$profile" > "$target"
+    launchctl unload "$target" 2>/dev/null || true
+    if launchctl load -w "$target"; then
+      print_success "Installed and loaded launch agent: %s\n" "$target"
+      print_warning "The VPN will now connect at login and auto-reconnect if it drops. Remove with: %s service uninstall '%s'\n" "${PROGRAM_NAME}" "$profile"
+    else
+      print_danger "Wrote %s but could not load it; load manually with: launchctl load -w '%s'\n" "$target" "$target"
+      return 1
+    fi
+  else
+    mkdir -p "$SYSTEMD_USER_DIR"
+    write_systemd_unit "$profile" > "$target"
+    if command -v systemctl >/dev/null 2>&1; then
+      systemctl --user daemon-reload
+      if systemctl --user enable --now "$(basename "$target")"; then
+        print_success "Installed and started systemd user unit: %s\n" "$target"
+      else
+        print_danger "Wrote %s but could not start it; check: systemctl --user status %s\n" "$target" "$(basename "$target")"
+        return 1
+      fi
+    else
+      print_warning "Wrote %s; systemctl not found, enable it manually.\n" "$target"
+    fi
+  fi
+}
+
+service_uninstall() {
+  local profile="$1"
+  [ -n "$profile" ] || { echo "Usage: ${PROGRAM_NAME} service uninstall <profile>" >&2; return 1; }
+  local target; target="$(_service_path_for "$profile")"
+  if [ ! -f "$target" ]; then
+    print_warning "No service installed for '%s' (%s).\n" "$profile" "$target"
+    return 0
+  fi
+  if [ "$(uname)" = "Darwin" ]; then
+    launchctl unload -w "$target" 2>/dev/null || true
+  else
+    command -v systemctl >/dev/null 2>&1 && systemctl --user disable --now "$(basename "$target")" 2>/dev/null || true
+  fi
+  rm -f "$target"
+  print_success "Removed service for '%s'.\n" "$profile"
+  print_warning "If the VPN is still connected, stop it with: %s stop '%s'\n" "${PROGRAM_NAME}" "$profile"
+}
+
+service_status() {
+  local found=0 f
+  if [ "$(uname)" = "Darwin" ]; then
+    for f in "$LAUNCH_AGENT_DIR/$SERVICE_LABEL_PREFIX".*.plist; do
+      [ -e "$f" ] || continue
+      found=1
+      local label; label="$(basename "$f" .plist)"
+      if launchctl list 2>/dev/null | grep -q "$label"; then
+        print_success "loaded   %s\n" "$f"
+      else
+        print_warning "unloaded %s\n" "$f"
+      fi
+    done
+  else
+    for f in "$SYSTEMD_USER_DIR"/vpn-up-*.service; do
+      [ -e "$f" ] || continue
+      found=1
+      local unit; unit="$(basename "$f")"
+      if command -v systemctl >/dev/null 2>&1 && systemctl --user is-active --quiet "$unit" 2>/dev/null; then
+        print_success "active   %s\n" "$f"
+      else
+        print_warning "inactive %s\n" "$f"
+      fi
+    done
+  fi
+  [ "$found" -eq 0 ] && print_warning "No VPN services installed.\n"
+  return 0
+}

--- a/setup.sh
+++ b/setup.sh
@@ -44,6 +44,10 @@ readonly SHOW_BANNER=__SHOW_BANNER__
 #        ├ TRUE          Show the ASCII banner on start (interactive only)
 #        └ FALSE         Never show the banner
 
+readonly NOTIFICATIONS=__NOTIFICATIONS__
+#        ├ TRUE          Desktop notification on connect/disconnect
+#        └ FALSE         No notifications
+
 # ENCRYPTION
 readonly ENCRYPTION_ENABLED=TRUE  # Toggle affects only file fallback; keychain/keyring are preferred.
 CFG
@@ -51,6 +55,7 @@ CFG
   sed -i.bak "s/__BACKGROUND__/${__WZ_BACKGROUND}/" "${tmp}"
   sed -i.bak "s/__QUIET__/${__WZ_QUIET}/" "${tmp}"
   sed -i.bak "s/__SHOW_BANNER__/${__WZ_SHOW_BANNER}/" "${tmp}"
+  sed -i.bak "s/__NOTIFICATIONS__/${__WZ_NOTIFICATIONS}/" "${tmp}"
   rm -f "${tmp}.bak"
   mv "${tmp}" "${CONFIGURATION_FILE}"
   chmod 600 "${CONFIGURATION_FILE}"
@@ -132,6 +137,9 @@ setup_wizard() {
 
   read -r -p "Show ASCII banner on start? (TRUE/FALSE) [TRUE]: " _in_banner
   __WZ_SHOW_BANNER="$(_bool_default "${_in_banner}" "TRUE")"
+
+  read -r -p "Desktop notifications on connect/disconnect? (TRUE/FALSE) [TRUE]: " _in_notif
+  __WZ_NOTIFICATIONS="$(_bool_default "${_in_notif}" "TRUE")"
 
   # Clean up any sudo password stored by older versions; storing it defeats
   # sudo's protection (any process running as this user could retrieve it).

--- a/tests/service.bats
+++ b/tests/service.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# Tests for service file generation (no launchctl/systemctl calls).
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  export VPN_UP_LAUNCH_AGENT_DIR="$BATS_TEST_TMPDIR/agents"
+  export VPN_UP_SYSTEMD_DIR="$BATS_TEST_TMPDIR/systemd"
+  mkdir -p "$DATA_DIR"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { :; }; print_danger() { :; }; print_success() { :; }; print_primary() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../service.sh"
+}
+
+@test "write_launch_agent_plist produces valid plist with service env and profile" {
+  run write_launch_agent_plist "My Work & VPN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<string>My Work &amp; VPN</string>"* ]]
+  [[ "$output" == *"com.sorinipate.vpn-up.My_Work___VPN"* ]]
+  [[ "$output" == *"<key>VPN_UP_SERVICE</key>"* ]]
+  [[ "$output" == *"<key>KeepAlive</key>"* ]]
+  # well-formed XML
+  printf '%s\n' "$output" | xmlstarlet val -q -
+}
+
+@test "write_systemd_unit produces a unit with restart and service env" {
+  run write_systemd_unit "Work VPN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'ExecStart='*'start "Work VPN"'* ]]
+  [[ "$output" == *"Environment=VPN_UP_SERVICE=1"* ]]
+  [[ "$output" == *"Restart=always"* ]]
+}
+
+@test "_service_path_for uses slugged per-profile filenames" {
+  if [ "$(uname)" = "Darwin" ]; then
+    [ "$(_service_path_for "Work VPN")" = "$VPN_UP_LAUNCH_AGENT_DIR/com.sorinipate.vpn-up.Work_VPN.plist" ]
+  else
+    [ "$(_service_path_for "Work VPN")" = "$VPN_UP_SYSTEMD_DIR/vpn-up-Work_VPN.service" ]
+  fi
+}

--- a/ui.sh
+++ b/ui.sh
@@ -18,6 +18,17 @@ readonly ASCII_ART='
 PRIMARY="${PRIMARY:-\x1b[36;1m}"
 RESET="${RESET:-\x1b[0m}"
 
+# Desktop notification on connect/disconnect (best-effort, never fatal).
+notify() {
+  [ "${NOTIFICATIONS:-TRUE}" = TRUE ] || return 0
+  local title="$1" message="$2"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display notification \"${message//\"/\\\"}\" with title \"${title//\"/\\\"}\"" >/dev/null 2>&1 || true
+  elif command -v notify-send >/dev/null 2>&1; then
+    notify-send "$title" "$message" 2>/dev/null || true
+  fi
+}
+
 show_banner() {
   # Only show when interactive and enabled; independent of QUIET, which
   # controls openconnect's output verbosity.

--- a/vpn-up.command
+++ b/vpn-up.command
@@ -46,6 +46,7 @@ unset _legacy_file
 . "${PROGRAM_PATH}/profiles.sh"
 . "${PROGRAM_PATH}/core.sh"
 . "${PROGRAM_PATH}/setup.sh"
+. "${PROGRAM_PATH}/service.sh"
 
 # Default colors if config not yet present
 PRIMARY="\x1b[36;1m"; SUCCESS="\x1b[32;1m"; WARNING="\x1b[35;1m"; DANGER="\x1b[31;1m"; RESET="\x1b[0m"
@@ -63,6 +64,9 @@ Commands:
   logs [-f] [profile]  Show the connection log (-f to follow)
   setup                Run setup wizard (regenerate config)
   add-profile          Add a VPN profile interactively (incl. secret + pin)
+  service install <p>  Connect at login + auto-reconnect (launchd/systemd)
+  service uninstall <p> Remove the login service for a profile
+  service status       List installed VPN services
   set-secret           Save a secret field for a profile (e.g., password)
   delete-secret        Delete a stored secret for a profile
   pin <host[:port]>    Print the pin-sha256 value for a gateway's certificate
@@ -88,6 +92,13 @@ case "${1:-}" in
   logs)       shift; show_logs "$@" ;;
   setup)      setup_wizard ;;
   add-profile) add_profile_wizard ;;
+  service)    shift; sub="${1:-}"
+              case "$sub" in
+                install)   service_install "${2:-}" ;;
+                uninstall) service_uninstall "${2:-}" ;;
+                status|"") service_status ;;
+                *)         echo "Usage: $0 service install|uninstall <profile> | service status"; exit 1 ;;
+              esac ;;
   set-secret) shift; profile="${1:-}"; field="${2:-}"; { [ -z "$profile" ] || [ -z "$field" ]; } && { echo "Usage: $0 set-secret <profile> <field>"; exit 1; }
               [ "$field" = "sudo_password" ] && { echo "Storing the sudo password is not supported (it would defeat sudo's protection). See the sudoers rule in the README." >&2; exit 1; }
               read -r -s -p "Enter value for ${profile}.${field}: " value; echo


### PR DESCRIPTION
## Added
- `service install|uninstall|status` — launchd user agent (macOS) / systemd user unit (Linux); supervises openconnect in the foreground and auto-reconnects on drop (30s throttle). Preflight checks for passwordless sudo, stored password, and non-interactive 2FA.
- Desktop notifications on connect/disconnect/failure (osascript / notify-send), gated by a new `NOTIFICATIONS` setting.
- Foreground sessions record their own PID/state so `status`/`stop` work during foreground and service sessions.

## Notes
- Service mode never prompts: `sudo -n`, stored-secret requirement, passcode-2FA guard.
- 24 bats tests passing, shellcheck clean.