### PR TITLE
Document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,18 @@ This project is intended for **legitimate and authorized VPN access only**.
 
 ## 🛠 Installation
 
-### macOS (Apple Silicon / Intel)
+### Homebrew (macOS / Linux — recommended)
+
+```bash
+brew tap sorinipate/vpn-up
+brew install vpn-up
+```
+
+Installs the `vpn-up` command with all dependencies (modern Bash,
+openconnect, xmlstarlet) and bash completion. Your data stays in
+`~/.config/vpn-up` either way.
+
+### Manual — macOS (Apple Silicon / Intel)
 
 macOS ships with Bash 3.2. Install modern Bash:
 
@@ -103,7 +114,7 @@ Or hard-wire the shebang in `vpn-up.command`:
 
 ---
 
-### Linux
+### Manual — Linux
 
 ```bash
 # Debian / Ubuntu


### PR DESCRIPTION
Adds install instructions for the new `sorinipate/vpn-up` Homebrew tap (formula at sorinipate/homebrew-vpn-up; verified with a real install, `brew test`, and a clean `brew audit --strict`).