### PR TITLE
Bump CI actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,20 @@ jobs:
         run: shellcheck --shell=bash --external-sources vpn-up.command *.sh
 
   tests:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y bats xmlstarlet openssl
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y bats xmlstarlet openssl
+          else
+            brew install bats-core xmlstarlet bash
+          fi
       - name: Run bats tests
         run: bats tests/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Lint scripts
@@ -18,7 +18,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y bats xmlstarlet openssl
       - name: Run bats tests
@@ -27,9 +27,9 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core.sh
+++ b/core.sh
@@ -4,8 +4,8 @@
 # owned by the current user and not writable by group/other.
 assert_safe_to_source() {
   local f="$1" owner perms
-  owner="$(stat -f '%u' "$f" 2>/dev/null || stat -c '%u' "$f" 2>/dev/null)"
-  perms="$(stat -f '%Lp' "$f" 2>/dev/null || stat -c '%a' "$f" 2>/dev/null)"
+  owner="$(file_owner_uid "$f")"
+  perms="$(file_mode "$f")"
   if [ "$owner" != "$(id -u)" ]; then
     print_danger "Refusing to load %s: not owned by the current user.\n" "$f"
     return 1

--- a/logging.sh
+++ b/logging.sh
@@ -11,6 +11,12 @@ STATE_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.state"
 # Filesystem-safe slug for a profile name (spaces etc. become '_').
 profile_slug() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
 
+# Portable stat wrappers. GNU form (-c) first: BSD stat fails on -c so the
+# fallback fires, whereas GNU stat treats -f as "filesystem info" and would
+# SUCCEED with garbage if tried first.
+file_owner_uid() { stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1" 2>/dev/null; }
+file_mode()      { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
 # Point the PID/LOG/STATE globals at a specific profile's files.
 # shellcheck disable=SC2034  # globals are consumed by core.sh
 set_profile_paths() {

--- a/service.sh
+++ b/service.sh
@@ -154,8 +154,8 @@ service_uninstall() {
   fi
   if [ "$(uname)" = "Darwin" ]; then
     launchctl unload -w "$target" 2>/dev/null || true
-  else
-    command -v systemctl >/dev/null 2>&1 && systemctl --user disable --now "$(basename "$target")" 2>/dev/null || true
+  elif command -v systemctl >/dev/null 2>&1; then
+    systemctl --user disable --now "$(basename "$target")" 2>/dev/null || true
   fi
   rm -f "$target"
   print_success "Removed service for '%s'.\n" "$profile"

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -60,12 +60,11 @@ setup() {
 }
 
 @test "vault and plain files are created with 600 permissions" {
+  source "$BATS_TEST_DIRNAME/../logging.sh"
   secrets_set_openssl "$(secrets_key D password)" "v"
   secrets_set_file "$(secrets_key D password)" "v"
-  perms_enc="$(stat -f '%Lp' "$SECRETS_VAULT" 2>/dev/null || stat -c '%a' "$SECRETS_VAULT")"
-  perms_plain="$(stat -f '%Lp' "$SECRETS_PLAIN" 2>/dev/null || stat -c '%a' "$SECRETS_PLAIN")"
-  [ "$perms_enc" = "600" ]
-  [ "$perms_plain" = "600" ]
+  [ "$(file_mode "$SECRETS_VAULT")" = "600" ]
+  [ "$(file_mode "$SECRETS_PLAIN")" = "600" ]
 }
 
 @test "no plaintext temp files left behind" {


### PR DESCRIPTION
Fixes the Node 20 deprecation warnings: `actions/checkout@v4` → `v6`, `gitleaks/gitleaks-action@v2` → `v3`. Node 20 is removed from runners on 2026-09-16.