### PR TITLE
v3.5.0: remove-profile, lifecycle hooks, tap release automation

### DIFF
--- a/.github/workflows/release-tap.yml
+++ b/.github/workflows/release-tap.yml
@@ -1,0 +1,52 @@
+name: Update Homebrew tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute release tarball sha256
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          curl -sL "https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz" -o release.tar.gz
+          echo "TAG=${TAG}" >> "$GITHUB_ENV"
+          echo "SHA256=$(sha256sum release.tar.gz | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Update formula in sorinipate/homebrew-vpn-up
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/sorinipate/homebrew-vpn-up/contents/Formula/vpn-up.rb"
+          AUTH="Authorization: token ${TAP_TOKEN}"
+
+          # fetch current formula + blob sha
+          curl -sf -H "$AUTH" "$API" > current.json
+          FILE_SHA=$(python3 -c 'import json; print(json.load(open("current.json"))["sha"])')
+          python3 -c 'import json,base64; open("vpn-up.rb","w").write(base64.b64decode(json.load(open("current.json"))["content"]).decode())'
+
+          # patch url tag and sha256
+          python3 - <<PY
+          import re
+          src = open("vpn-up.rb").read()
+          src = re.sub(r'refs/tags/v[0-9][^"]*\.tar\.gz', 'refs/tags/${TAG}.tar.gz', src)
+          src = re.sub(r'sha256 "[0-9a-f]{64}"', 'sha256 "${SHA256}"', src)
+          open("vpn-up.rb","w").write(src)
+          PY
+          echo "--- updated formula ---"; grep -E 'url|sha256' vpn-up.rb
+
+          # commit back
+          python3 - <<PY > payload.json
+          import json,base64
+          body = {
+            "message": "vpn-up ${TAG}",
+            "content": base64.b64encode(open("vpn-up.rb","rb").read()).decode(),
+            "sha": "${FILE_SHA}",
+          }
+          print(json.dumps(body))
+          PY
+          curl -sf -X PUT -H "$AUTH" -H "Accept: application/vnd.github+json" "$API" -d @payload.json > /dev/null
+          echo "Tap updated to ${TAG}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.5.0] — 2026-06-12
+### Lifecycle & Maintenance Update
+
+### Added
+- `remove-profile <name>` — removes the XML block, the stored secret, the
+  per-profile PID/state/log files, and any installed login service in one
+  confirmed step; refuses while the profile is connected.
+- Lifecycle hooks: executable scripts in `~/.config/vpn-up/hooks/connected.d/`
+  and `disconnected.d/` run on tunnel up/down with `VPN_EVENT`, `VPN_NAME`,
+  and `VPN_HOST` in the environment. Hooks must be user-owned and not
+  group/world-writable or they are skipped; failures never block the VPN.
+- Release automation: publishing a GitHub release now updates the Homebrew
+  tap formula (url + sha256) automatically.
+
+### Changed
+- CI runs the test suite on macOS as well as Ubuntu (added post-v3.4.0
+  along with portable stat helpers that fixed config validation on Linux).
+
+---
+
 ## [v3.4.0] — 2026-06-12
 ### Service & Notifications Update
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ readonly ENCRYPTION_ENABLED=TRUE
 ./vpn-up.command start "Frankfurt VPN"  # connect directly (scriptable)
 ./vpn-up.command list                   # list configured profiles
 ./vpn-up.command add-profile            # guided profile creation (+ secret, + pin)
+./vpn-up.command remove-profile "Old VPN"  # remove profile + secret + logs + service
 ./vpn-up.command status                 # profile, gateway, uptime
 ./vpn-up.command logs -f                # follow the connection log
 ./vpn-up.command stop                   # stop the VPN (or: stop "Frankfurt VPN")
@@ -226,6 +227,25 @@ if the tunnel drops (30s throttle). Requirements:
 
 Desktop notifications fire on connect/disconnect (macOS Notification Center /
 `notify-send`); disable with `NOTIFICATIONS=FALSE` in the config.
+
+### Hooks
+
+Drop executable scripts into `~/.config/vpn-up/hooks/connected.d/` or
+`~/.config/vpn-up/hooks/disconnected.d/` and they run (in name order) when a
+tunnel comes up or goes down — mount shares, switch proxies, ping monitoring.
+Hooks receive `VPN_EVENT`, `VPN_NAME`, and `VPN_HOST` in their environment
+(never the password). Because hooks are executable code, a hook is **skipped
+unless it is owned by you and not group/world-writable** — same rule as the
+config file. Hook failures are reported but never block the VPN.
+
+```bash
+mkdir -p ~/.config/vpn-up/hooks/connected.d
+cat > ~/.config/vpn-up/hooks/connected.d/10-hello <<'EOF'
+#!/bin/sh
+echo "$(date): $VPN_NAME up ($VPN_HOST)" >> "$HOME/vpn-history.log"
+EOF
+chmod 700 ~/.config/vpn-up/hooks/connected.d/10-hello
+```
 
 ### Shell completion
 ```bash

--- a/completions/vpn-up.bash
+++ b/completions/vpn-up.bash
@@ -22,7 +22,7 @@ _vpn_up() {
   cmd="${COMP_WORDS[1]:-}"
 
   if [ "$COMP_CWORD" -eq 1 ]; then
-    mapfile -t COMPREPLY < <(compgen -W "start stop status restart list logs setup add-profile service set-secret delete-secret pin doctor" -- "$cur")
+    mapfile -t COMPREPLY < <(compgen -W "start stop status restart list logs setup add-profile remove-profile service set-secret delete-secret pin doctor" -- "$cur")
     return
   fi
 
@@ -34,7 +34,7 @@ _vpn_up() {
         _vpn_up_complete_profiles "$cur"
       fi
       ;;
-    start|restart|stop)
+    start|restart|stop|remove-profile)
       [ "$COMP_CWORD" -eq 2 ] && _vpn_up_complete_profiles "$cur"
       ;;
     set-secret|delete-secret)

--- a/core.sh
+++ b/core.sh
@@ -26,7 +26,7 @@ run_hooks() {
   local dir="${DATA_DIR}/hooks/${event}.d" h
   [ -d "$dir" ] || return 0
   for h in "$dir"/*; do
-    [ -f "$h" ] && [ -x "$h" ] || continue
+    { [ -f "$h" ] && [ -x "$h" ]; } || continue
     if ! assert_safe_to_source "$h"; then
       print_warning "Skipping hook %s (unsafe ownership/permissions).\n" "$h"
       continue

--- a/core.sh
+++ b/core.sh
@@ -16,6 +16,28 @@ assert_safe_to_source() {
   fi
 }
 
+# Run user hook scripts for a lifecycle event (connected/disconnected) from
+# ${DATA_DIR}/hooks/<event>.d/, in name order. Hooks are executable code, so
+# each gets the same ownership/permission check as the config file; failures
+# are reported but never abort the VPN flow. Hooks receive VPN_EVENT,
+# VPN_NAME, and VPN_HOST in their environment (never the password).
+run_hooks() {
+  local event="$1" name="${2:-}" host="${3:-}"
+  local dir="${DATA_DIR}/hooks/${event}.d" h
+  [ -d "$dir" ] || return 0
+  for h in "$dir"/*; do
+    [ -f "$h" ] && [ -x "$h" ] || continue
+    if ! assert_safe_to_source "$h"; then
+      print_warning "Skipping hook %s (unsafe ownership/permissions).\n" "$h"
+      continue
+    fi
+    if ! VPN_EVENT="$event" VPN_NAME="$name" VPN_HOST="$host" "$h"; then
+      print_warning "Hook %s exited non-zero.\n" "$h"
+    fi
+  done
+  return 0
+}
+
 # Source the config (executable shell) after the safety checks. Safe to call
 # from any command; no-op when the config doesn't exist yet.
 load_config() {
@@ -96,6 +118,7 @@ start() {
       write_connection_state
       print_success "Connected to %s\n" "${VPN_NAME}"
       notify "VPN Up" "Connected to ${VPN_NAME}"
+      run_hooks connected "${VPN_NAME}" "${VPN_HOST}"
       print_current_ip_address
     else
       print_danger "Failed to connect! Last log lines from %s:\n" "${LOG_FILE_PATH}"
@@ -232,11 +255,15 @@ _stop_by_pid_file() {
     print_danger "Could not stop openconnect (PID: %s); VPN may still be up!\n" "$pid"
     return 1
   fi
-  local profile=""
-  [ -f "$statefile" ] && profile="$(awk -F= '$1=="profile"{print substr($0,9); exit}' "$statefile")"
+  local profile="" host=""
+  if [ -f "$statefile" ]; then
+    profile="$(awk -F= '$1=="profile"{print substr($0,9); exit}' "$statefile")"
+    host="$(awk -F= '$1=="host"{print substr($0,6); exit}' "$statefile")"
+  fi
   rm -f "$pidfile" "$statefile"
   print_success "VPN stopped.\n"
   notify "VPN Up" "Disconnected from ${profile:-VPN}"
+  run_hooks disconnected "$profile" "$host"
 }
 
 stop() {
@@ -326,6 +353,7 @@ run_openconnect() {
       if [ -n "$_pid" ]; then
         printf '%s\n' "$_pid" > "$PID_FILE_PATH"
         notify "VPN Up" "Connected to ${VPN_NAME}"
+        run_hooks connected "${VPN_NAME}" "${VPN_HOST}"
       fi
     ) &
     printf "%s\n" "$stdin_lines" \
@@ -333,6 +361,7 @@ run_openconnect() {
     # Foreground session over (disconnect or failure): clean our records.
     rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
     notify "VPN Up" "Disconnected from ${VPN_NAME:-VPN}"
+    run_hooks disconnected "${VPN_NAME:-}" "${VPN_HOST:-}"
   fi
 
   # Drop the password from shell memory as soon as it has been piped.

--- a/setup.sh
+++ b/setup.sh
@@ -123,6 +123,56 @@ add_profile_wizard() {
   fi
 }
 
+# Remove a profile and everything attached to it: XML block, stored secret,
+# per-profile pid/state/log files, and any installed login service.
+remove_profile() {
+  local name="$1"
+  [ -n "$name" ] || { echo "Usage: ${PROGRAM_NAME} remove-profile <profile>" >&2; return 1; }
+  if ! profile_exists "$name"; then
+    print_danger "Unknown profile '%s'.\n" "$name"
+    return 1
+  fi
+
+  local slug; slug="$(profile_slug "$name")"
+  local pidfile="${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.pid"
+  if [ -f "$pidfile" ] && is_openconnect_pid "$(cat "$pidfile")"; then
+    print_danger "Profile '%s' is currently connected; stop it first: %s stop '%s'\n" "$name" "${PROGRAM_NAME}" "$name"
+    return 1
+  fi
+
+  local _confirm=""
+  read -r -p "Remove profile '${name}', its stored secret, logs, and any login service? [y/N]: " _confirm
+  case "$_confirm" in y|Y|yes|YES) : ;; *) print_warning "Aborted.\n"; return 1 ;; esac
+
+  # login service (also unloads it)
+  if [ -f "$(_service_path_for "$name")" ]; then
+    service_uninstall "$name"
+  fi
+
+  # stored secret
+  secrets_delete "$name" "password"
+
+  # XML block
+  local name_lit; name_lit="$(xpath_literal "$name")"
+  local tmp="${PROFILES_FILE}.tmp"
+  if xmlstarlet ed -d "//VPN[name=${name_lit}]" "${PROFILES_FILE}" > "${tmp}"; then
+    mv "${tmp}" "${PROFILES_FILE}"
+    chmod 600 "${PROFILES_FILE}" 2>/dev/null || true
+  else
+    rm -f "${tmp}"
+    print_danger "Could not update %s; profile not removed from XML.\n" "${PROFILES_FILE}"
+    return 1
+  fi
+
+  # per-profile state and logs
+  rm -f "$pidfile" \
+        "${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.state" \
+        "${DATA_DIR}/logs/${PROGRAM_NAME}.${slug}.log" \
+        "${DATA_DIR}/logs/service.${slug}.log"
+
+  print_success "Removed profile '%s' (XML, secret, state, logs, service).\n" "$name"
+}
+
 setup_wizard() {
   printf "%b\n" "${PRIMARY}Running first-time setup...${RESET}"
 

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Tests for remove-profile and the lifecycle hooks runner.
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>Doomed VPN</name><protocol>anyconnect</protocol><host>d.example.com</host><user>u1</user><password></password></VPN>
+  <VPN><name>Keeper VPN</name><protocol>gp</protocol><host>k.example.com</host><user>u2</user><password></password></VPN>
+</VPNs>
+XML
+  print_warning() { :; }; print_danger() { :; }; print_success() { :; }; print_primary() { :; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+  source "$BATS_TEST_DIRNAME/../setup.sh"
+  # stubs for remove_profile collaborators
+  _service_path_for() { echo "$BATS_TEST_TMPDIR/no-such-service"; }
+  service_uninstall() { echo "uninstalled:$1" >> "$BATS_TEST_TMPDIR/calls"; }
+  secrets_delete() { echo "secret-deleted:$1.$2" >> "$BATS_TEST_TMPDIR/calls"; }
+  is_openconnect_pid() { return 1; }
+}
+
+@test "remove_profile deletes the block, secret, and files; keeps others" {
+  touch "$DATA_DIR/pids/${PROGRAM_NAME}.Doomed_VPN.state" "$DATA_DIR/logs/${PROGRAM_NAME}.Doomed_VPN.log"
+  remove_profile "Doomed VPN" <<< "y"
+  ! profile_exists "Doomed VPN"
+  profile_exists "Keeper VPN"
+  grep -q "secret-deleted:Doomed VPN.password" "$BATS_TEST_TMPDIR/calls"
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Doomed_VPN.state" ]
+  [ ! -e "$DATA_DIR/logs/${PROGRAM_NAME}.Doomed_VPN.log" ]
+  xmlstarlet val -q "$PROFILES_FILE"
+}
+
+@test "remove_profile aborts without confirmation" {
+  run remove_profile "Doomed VPN" <<< "n"
+  [ "$status" -ne 0 ]
+  profile_exists "Doomed VPN"
+}
+
+@test "remove_profile refuses while profile is connected" {
+  is_openconnect_pid() { return 0; }
+  echo "12345" > "$DATA_DIR/pids/${PROGRAM_NAME}.Doomed_VPN.pid"
+  run remove_profile "Doomed VPN" <<< "y"
+  [ "$status" -ne 0 ]
+  profile_exists "Doomed VPN"
+}
+
+@test "run_hooks executes safe hooks with event env, skips unsafe ones" {
+  mkdir -p "$DATA_DIR/hooks/connected.d"
+  cat > "$DATA_DIR/hooks/connected.d/10-good" <<'EOF'
+#!/bin/sh
+echo "$VPN_EVENT/$VPN_NAME/$VPN_HOST" > "$OUT"
+EOF
+  cat > "$DATA_DIR/hooks/connected.d/20-unsafe" <<'EOF'
+#!/bin/sh
+echo "unsafe ran" >> "$OUT"
+EOF
+  chmod 700 "$DATA_DIR/hooks/connected.d/10-good"
+  chmod 777 "$DATA_DIR/hooks/connected.d/20-unsafe"   # group/world writable -> must be skipped
+  export OUT="$BATS_TEST_TMPDIR/hook-out"
+  run_hooks connected "Work VPN" "w.example.com"
+  [ "$(cat "$OUT")" = "connected/Work VPN/w.example.com" ]
+  ! grep -q "unsafe ran" "$OUT"
+}
+
+@test "run_hooks is a no-op without a hooks dir and tolerates failing hooks" {
+  run run_hooks disconnected "X" "Y"
+  [ "$status" -eq 0 ]
+  mkdir -p "$DATA_DIR/hooks/disconnected.d"
+  printf '#!/bin/sh\nexit 7\n' > "$DATA_DIR/hooks/disconnected.d/fail"
+  chmod 700 "$DATA_DIR/hooks/disconnected.d/fail"
+  run run_hooks disconnected "X" "Y"
+  [ "$status" -eq 0 ]
+}

--- a/vpn-up.command
+++ b/vpn-up.command
@@ -64,6 +64,7 @@ Commands:
   logs [-f] [profile]  Show the connection log (-f to follow)
   setup                Run setup wizard (regenerate config)
   add-profile          Add a VPN profile interactively (incl. secret + pin)
+  remove-profile <p>   Remove a profile (XML, secret, logs, service)
   service install <p>  Connect at login + auto-reconnect (launchd/systemd)
   service uninstall <p> Remove the login service for a profile
   service status       List installed VPN services
@@ -92,6 +93,7 @@ case "${1:-}" in
   logs)       shift; show_logs "$@" ;;
   setup)      setup_wizard ;;
   add-profile) add_profile_wizard ;;
+  remove-profile) remove_profile "${2:-}" ;;
   service)    shift; sub="${1:-}"
               case "$sub" in
                 install)   service_install "${2:-}" ;;


### PR DESCRIPTION
## Added
- `remove-profile <name>` — removes XML block, stored secret, per-profile state/logs, and any login service in one confirmed step; refuses while connected.
- Lifecycle hooks (`hooks/connected.d`, `hooks/disconnected.d`) with the same ownership/permission safety rules as the config; receive `VPN_EVENT`/`VPN_NAME`/`VPN_HOST`, never the password.
- `release-tap` workflow: publishing a release auto-bumps the Homebrew formula (url + sha256) in `sorinipate/homebrew-vpn-up`.

29 bats tests passing (5 new), shellcheck clean. The v3.5.0 release itself will be the live test of the tap automation.