### PR TITLE
v3.5.1: review fixes + full-application test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.5.1] — 2026-06-13
+### Review & Coverage Update
+
+### Fixed
+- Homebrew installs: the `vpn-up` wrapper now resolves through the stable
+  `opt` path, so login services installed from a brew copy survive
+  `brew upgrade` (previously the LaunchAgent pointed at a versioned Cellar
+  path). Tap formula change; reinstall or upgrade picks it up.
+- `service status` matched launchd labels as a regex; now an exact match.
+- Config validation fails closed if file permissions cannot be determined.
+- After a `Login failed` connection attempt, the error now points at
+  `delete-secret` so a mistyped stored password isn't silently reused.
+
+### Added
+- Test coverage across the whole application: CLI dispatch, status/stop scan
+  logic, config safety checks, log selection, notifications/banner gating,
+  setup templating, secrets backend selection, service install/uninstall,
+  and helper parsing — 71 bats tests total (up from 29), run on macOS and
+  Ubuntu in CI.
+
+---
+
 ## [v3.5.0] — 2026-06-12
 ### Lifecycle & Maintenance Update
 

--- a/core.sh
+++ b/core.sh
@@ -10,6 +10,10 @@ assert_safe_to_source() {
     print_danger "Refusing to load %s: not owned by the current user.\n" "$f"
     return 1
   fi
+  if [ -z "$perms" ]; then
+    print_danger "Refusing to load %s: could not determine file permissions.\n" "$f"
+    return 1
+  fi
   if [ $(( 8#$perms & 8#022 )) -ne 0 ]; then
     print_danger "Refusing to load %s: writable by group/other (mode %s). Fix with: chmod 600 '%s'\n" "$f" "$perms" "$f"
     return 1
@@ -123,6 +127,9 @@ start() {
     else
       print_danger "Failed to connect! Last log lines from %s:\n" "${LOG_FILE_PATH}"
       tail -n 15 "$LOG_FILE_PATH" 2>/dev/null || true
+      if grep -q "Login failed" "$LOG_FILE_PATH" 2>/dev/null; then
+        print_warning "If the stored password is wrong, reset it with: %s delete-secret '%s' password\n" "${PROGRAM_NAME}" "${VPN_NAME}"
+      fi
       notify "VPN Up" "Failed to connect to ${VPN_NAME:-VPN}"
     fi
   fi

--- a/service.sh
+++ b/service.sh
@@ -169,7 +169,7 @@ service_status() {
       [ -e "$f" ] || continue
       found=1
       local label; label="$(basename "$f" .plist)"
-      if launchctl list 2>/dev/null | grep -q "$label"; then
+      if launchctl list 2>/dev/null | grep -qF "$label"; then
         print_success "loaded   %s\n" "$f"
       else
         print_warning "unloaded %s\n" "$f"

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# End-to-end CLI dispatch tests against the real entry point in a sandbox.
+
+setup() {
+  export VPN_UP_HOME="$BATS_TEST_TMPDIR/home"
+  mkdir -p "$VPN_UP_HOME"
+  CLI="$BATS_TEST_DIRNAME/../vpn-up.command"
+  cat > "$VPN_UP_HOME/vpn-up.command.profiles" <<'XML'
+<VPNs>
+  <VPN><name>CLI VPN</name><protocol>anyconnect</protocol><host>cli.example.com</host><user>u</user><password></password><duo2FAMethod>push</duo2FAMethod></VPN>
+</VPNs>
+XML
+  chmod 600 "$VPN_UP_HOME/vpn-up.command.profiles"
+}
+
+@test "no arguments prints usage" {
+  run "$CLI"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"start [profile]"* ]]
+}
+
+@test "unknown command prints usage" {
+  run "$CLI" frobnicate
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "set-secret requires profile and field" {
+  run "$CLI" set-secret
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "set-secret refuses to store a sudo password" {
+  run "$CLI" set-secret __GLOBAL__ sudo_password
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not supported"* ]]
+}
+
+@test "delete-secret requires profile and field" {
+  run "$CLI" delete-secret onlyone
+  [ "$status" -eq 1 ]
+}
+
+@test "pin requires a host or --save profile" {
+  run "$CLI" pin
+  [ "$status" -eq 1 ]
+  run "$CLI" pin --save
+  [ "$status" -eq 1 ]
+}
+
+@test "list shows seeded profile" {
+  run "$CLI" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CLI VPN"* ]]
+  [[ "$output" == *"cli.example.com"* ]]
+}
+
+@test "list-names emits bare names for completion" {
+  run "$CLI" list-names
+  [ "$output" = "CLI VPN" ]
+}
+
+@test "status reports not running in a fresh sandbox" {
+  run "$CLI" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not running"* ]]
+}
+
+@test "logs warns when there is no log yet" {
+  run "$CLI" logs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No log file yet"* ]]
+}
+
+@test "remove-profile requires an argument and rejects unknown profiles" {
+  run "$CLI" remove-profile
+  [ "$status" -eq 1 ]
+  run "$CLI" remove-profile "Ghost"
+  [ "$status" -eq 1 ]
+}
+
+@test "service requires a valid subcommand" {
+  run "$CLI" service bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# Tests for core.sh: config safety, status/stop scan logic, connection state.
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export CONFIGURATION_FILE="$DATA_DIR/cfg"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { printf -- "$1" "${@:2}"; }
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_success() { printf -- "$1" "${@:2}"; }
+  print_primary() { printf -- "$1" "${@:2}"; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+# --- assert_safe_to_source ---
+
+@test "assert_safe_to_source accepts 600/644, rejects group/world-writable" {
+  f="$BATS_TEST_TMPDIR/file"; echo x > "$f"
+  chmod 600 "$f"; assert_safe_to_source "$f"
+  chmod 644 "$f"; assert_safe_to_source "$f"
+  chmod 664 "$f"; run assert_safe_to_source "$f"; [ "$status" -ne 0 ]
+  chmod 602 "$f"; run assert_safe_to_source "$f"; [ "$status" -ne 0 ]
+}
+
+@test "assert_safe_to_source rejects missing files" {
+  run assert_safe_to_source "$BATS_TEST_TMPDIR/does-not-exist"
+  [ "$status" -ne 0 ]
+}
+
+# --- connection state + status ---
+
+@test "write_connection_state records profile/host with 600 perms" {
+  VPN_NAME="Test VPN"; VPN_HOST="t.example.com"
+  STATE_FILE_PATH="$DATA_DIR/pids/${PROGRAM_NAME}.Test_VPN.state"
+  write_connection_state
+  [ "$(file_mode "$STATE_FILE_PATH")" = "600" ]
+  grep -q "^profile=Test VPN$" "$STATE_FILE_PATH"
+  grep -q "^host=t.example.com$" "$STATE_FILE_PATH"
+  grep -q "^connected_at=" "$STATE_FILE_PATH"
+}
+
+@test "status reports running profile details from the state file" {
+  echo "$$" > "$DATA_DIR/pids/${PROGRAM_NAME}.X.pid"
+  printf 'profile=X VPN\nhost=x.example.com\nconnected_at=2026-06-12 10:00:00\n' > "$DATA_DIR/pids/${PROGRAM_NAME}.X.state"
+  is_openconnect_pid() { return 0; }
+  run status
+  [[ "$output" == *"VPN is running (PID: $$)"* ]]
+  [[ "$output" == *"Profile : X VPN"* ]]
+  [[ "$output" == *"Gateway : x.example.com"* ]]
+}
+
+@test "status cleans stale pid/state files and reports not running" {
+  echo 99999 > "$DATA_DIR/pids/${PROGRAM_NAME}.Stale.pid"
+  touch "$DATA_DIR/pids/${PROGRAM_NAME}.Stale.state"
+  is_openconnect_pid() { return 1; }
+  run status
+  [[ "$output" == *"not running"* ]]
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Stale.pid" ]
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Stale.state" ]
+}
+
+# --- stop ---
+
+@test "stop kills via sudo, waits for death, removes pid and state" {
+  flag="$BATS_TEST_TMPDIR/alive"; touch "$flag"
+  is_openconnect_pid() { [ -e "$flag" ]; }
+  sudo() { [ "$1" = "kill" ] && rm -f "$flag"; return 0; }
+  load_config() { :; }
+  echo 4242 > "$DATA_DIR/pids/${PROGRAM_NAME}.Y.pid"
+  printf 'profile=Y\nhost=y.example.com\n' > "$DATA_DIR/pids/${PROGRAM_NAME}.Y.state"
+  run_hooks_called=""
+  run_hooks() { echo "$1:$2:$3" > "$BATS_TEST_TMPDIR/hookcall"; }
+  stop
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Y.pid" ]
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Y.state" ]
+  [ "$(cat "$BATS_TEST_TMPDIR/hookcall")" = "disconnected:Y:y.example.com" ]
+}
+
+@test "stop with profile arg targets only that profile" {
+  is_openconnect_pid() { return 1; }
+  load_config() { :; }
+  echo 1 > "$DATA_DIR/pids/${PROGRAM_NAME}.Keep.pid"
+  echo 2 > "$DATA_DIR/pids/${PROGRAM_NAME}.Gone.pid"
+  stop "Gone"
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Gone.pid" ]
+  [ -e "$DATA_DIR/pids/${PROGRAM_NAME}.Keep.pid" ]
+}
+
+@test "stop reports not running when no pid files exist" {
+  load_config() { :; }
+  run stop
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not running"* ]]
+}
+
+# --- load_config ---
+
+@test "load_config sources a safe config and refuses an unsafe one" {
+  echo 'MARKER=loaded' > "$CONFIGURATION_FILE"
+  chmod 600 "$CONFIGURATION_FILE"
+  load_config
+  [ "${MARKER:-}" = "loaded" ]
+  chmod 666 "$CONFIGURATION_FILE"
+  run load_config
+  [ "$status" -ne 0 ]
+}

--- a/tests/logging.bats
+++ b/tests/logging.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# Tests for logging.sh: paths, pid identity, log selection, print helpers.
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+}
+
+@test "set_profile_paths points globals at slugged per-profile files" {
+  set_profile_paths "My Work VPN"
+  [ "$PID_FILE_PATH" = "$DATA_DIR/pids/${PROGRAM_NAME}.My_Work_VPN.pid" ]
+  [ "$STATE_FILE_PATH" = "$DATA_DIR/pids/${PROGRAM_NAME}.My_Work_VPN.state" ]
+  [ "$LOG_FILE_PATH" = "$DATA_DIR/logs/${PROGRAM_NAME}.My_Work_VPN.log" ]
+}
+
+@test "is_openconnect_pid rejects empty, non-numeric, and non-openconnect pids" {
+  run is_openconnect_pid "";        [ "$status" -ne 0 ]
+  run is_openconnect_pid "12a4";    [ "$status" -ne 0 ]
+  run is_openconnect_pid "evil; rm" ; [ "$status" -ne 0 ]
+  # current shell is bash, not openconnect
+  run is_openconnect_pid "$$";      [ "$status" -ne 0 ]
+}
+
+@test "any_vpn_running scans pid files and survives an empty pids dir" {
+  run any_vpn_running; [ "$status" -ne 0 ]
+  echo "$$" > "$DATA_DIR/pids/a.pid"
+  is_openconnect_pid() { return 0; }
+  any_vpn_running
+}
+
+@test "file_mode and file_owner_uid report correct values" {
+  f="$BATS_TEST_TMPDIR/f"; touch "$f"; chmod 640 "$f"
+  [ "$(file_mode "$f")" = "640" ]
+  [ "$(file_owner_uid "$f")" = "$(id -u)" ]
+}
+
+@test "show_logs warns when no log exists" {
+  run show_logs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No log file yet"* ]]
+}
+
+@test "show_logs picks the named profile's log, or the most recent" {
+  echo "old log" > "$DATA_DIR/logs/${PROGRAM_NAME}.Old_VPN.log"
+  sleep 1
+  echo "new log" > "$DATA_DIR/logs/${PROGRAM_NAME}.New_VPN.log"
+  run show_logs "Old VPN"
+  [ "$output" = "old log" ]
+  run show_logs
+  [ "$output" = "new log" ]
+}
+
+@test "print helpers substitute arguments into literal formats" {
+  out="$(print_warning "a %s b\n" "VALUE")"
+  [[ "$out" == *"a VALUE b"* ]]
+  out="$(print_danger "%s-%s\n" x y)"
+  [[ "$out" == *"x-y"* ]]
+}
+
+@test "check_file_existence exits non-zero for missing files" {
+  run check_file_existence "$BATS_TEST_TMPDIR/nope" "Profiles"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Profiles file missing"* ]]
+}

--- a/tests/network.bats
+++ b/tests/network.bats
@@ -50,3 +50,10 @@ XML
   run pin_save "No Host"
   [ "$status" -ne 0 ]
 }
+
+@test "_host_only and _port_only split host:port with a 443 default" {
+  [ "$(_host_only "vpn.example.com")" = "vpn.example.com" ]
+  [ "$(_port_only "vpn.example.com")" = "443" ]
+  [ "$(_host_only "vpn.example.com:8443")" = "vpn.example.com" ]
+  [ "$(_port_only "vpn.example.com:8443")" = "8443" ]
+}

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -111,3 +111,16 @@ XML
   [[ "${lines[2]}" == "Other VPN"* ]]
   [ "${#lines[@]}" -eq 3 ]
 }
+
+@test "set_protocol_description maps known protocols and flags unknown" {
+  PROTOCOL=anyconnect; set_protocol_description; [ "$PROTOCOL_DESCRIPTION" = "Cisco AnyConnect" ]
+  PROTOCOL=gp;         set_protocol_description; [ "$PROTOCOL_DESCRIPTION" = "Palo Alto GlobalProtect" ]
+  PROTOCOL=bogus;      set_protocol_description; [ "$PROTOCOL_DESCRIPTION" = "Unknown" ]
+}
+
+@test "set_2fa_method_description classifies push/passcode/custom/none" {
+  VPN_DUO2FAMETHOD=push;    set_2fa_method_description; [ "$VPN_DUO2FAMETHOD_DESCRIPTION" = "PUSH" ]
+  VPN_DUO2FAMETHOD=123456;  set_2fa_method_description; [ "$VPN_DUO2FAMETHOD_DESCRIPTION" = "PASSCODE" ]
+  VPN_DUO2FAMETHOD=weird;   set_2fa_method_description; [ "$VPN_DUO2FAMETHOD_DESCRIPTION" = "CUSTOM" ]
+  VPN_DUO2FAMETHOD="";      set_2fa_method_description; [ "$VPN_DUO2FAMETHOD_DESCRIPTION" = "NONE" ]
+}

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -73,3 +73,32 @@ setup() {
   [ ! -e "$SECRETS_TMP" ]
   [ ! -e "${SECRETS_TMP}.sorted" ]
 }
+
+@test "secrets_key namespaces profile and field" {
+  [ "$(secrets_key "Work VPN" password)" = "${PROGRAM_NAME}:profile=Work VPN:field=password" ]
+}
+
+@test "_security_quote escapes quotes and backslashes for security -i" {
+  [ "$(_security_quote 'plain')" = '"plain"' ]
+  [ "$(_security_quote 'a"b')" = '"a\"b"' ]
+  [ "$(_security_quote 'a\b')" = '"a\\b"' ]
+}
+
+@test "secrets_backend honors platform tools and ENCRYPTION_ENABLED" {
+  # no keyring tools, encryption on -> openssl vault
+  uname() { echo Linux; }
+  command() { return 1; }
+  ENCRYPTION_ENABLED=TRUE
+  [ "$(secrets_backend)" = "openssl" ]
+  # explicit plaintext opt-out -> file
+  ENCRYPTION_ENABLED=FALSE
+  [ "$(secrets_backend)" = "file" ]
+  # Darwin with security available -> keychain regardless
+  uname() { echo Darwin; }
+  command() { [ "$2" = "security" ]; }
+  [ "$(secrets_backend)" = "keychain" ]
+  # Linux with secret-tool -> secret-tool
+  uname() { echo Linux; }
+  command() { [ "$2" = "secret-tool" ]; }
+  [ "$(secrets_backend)" = "secret-tool" ]
+}

--- a/tests/service.bats
+++ b/tests/service.bats
@@ -40,3 +40,46 @@ setup() {
     [ "$(_service_path_for "Work VPN")" = "$VPN_UP_SYSTEMD_DIR/vpn-up-Work_VPN.service" ]
   fi
 }
+
+# --- install/uninstall/status flows with stubbed service managers ---
+
+_setup_install_stubs() {
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>Svc VPN</name><protocol>anyconnect</protocol><host>s.example.com</host><user>u</user><password></password><duo2FAMethod>push</duo2FAMethod></VPN>
+  <VPN><name>Passcode VPN</name><protocol>anyconnect</protocol><host>p.example.com</host><user>u</user><password></password><duo2FAMethod>passcode</duo2FAMethod></VPN>
+</VPNs>
+XML
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  sudo() { return 0; }                 # passwordless sudo "present"
+  secrets_get() { echo "stored"; }     # password "stored"
+  launchctl() { echo "launchctl $*" >> "$BATS_TEST_TMPDIR/svc-calls"; return 0; }
+  systemctl() { echo "systemctl $*" >> "$BATS_TEST_TMPDIR/svc-calls"; return 0; }
+}
+
+@test "service_install writes the service file and loads it" {
+  _setup_install_stubs
+  service_install "Svc VPN"
+  [ -f "$(_service_path_for "Svc VPN")" ]
+  grep -q "Svc" "$(_service_path_for "Svc VPN")"
+  grep -qE "(launchctl load|systemctl --user enable)" "$BATS_TEST_TMPDIR/svc-calls"
+}
+
+@test "service_install refuses passcode-2FA profiles and unknown profiles" {
+  _setup_install_stubs
+  run service_install "Passcode VPN"
+  [ "$status" -ne 0 ]
+  run service_install "Ghost"
+  [ "$status" -ne 0 ]
+}
+
+@test "service_uninstall unloads and removes; status lists installed services" {
+  _setup_install_stubs
+  service_install "Svc VPN"
+  run service_status
+  [[ "$output" == *"Svc_VPN"* ]]
+  service_uninstall "Svc VPN"
+  [ ! -e "$(_service_path_for "Svc VPN")" ]
+  run service_uninstall "Svc VPN"   # idempotent
+  [ "$status" -eq 0 ]
+}

--- a/tests/ui_setup.bats
+++ b/tests/ui_setup.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Tests for ui.sh (banner/notify gating) and setup.sh (bool parsing, config template).
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR"
+  export CONFIGURATION_FILE="$DATA_DIR/${PROGRAM_NAME}.config"
+  print_warning() { :; }; print_danger() { :; }; print_success() { :; }; print_primary() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../ui.sh"
+  source "$BATS_TEST_DIRNAME/../setup.sh"
+}
+
+# --- notify ---
+
+_stub_notifiers() {
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+  for tool in osascript notify-send; do
+    cat > "$BATS_TEST_TMPDIR/bin/$tool" <<EOF
+#!/bin/sh
+echo "\$@" >> "$BATS_TEST_TMPDIR/notify-out"
+EOF
+    chmod 755 "$BATS_TEST_TMPDIR/bin/$tool"
+  done
+  PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+}
+
+@test "notify fires when NOTIFICATIONS=TRUE (default) and is silent when FALSE" {
+  _stub_notifiers
+  NOTIFICATIONS=TRUE notify "Title" "Message"
+  [ -f "$BATS_TEST_TMPDIR/notify-out" ]
+  grep -q "Message" "$BATS_TEST_TMPDIR/notify-out"
+  rm -f "$BATS_TEST_TMPDIR/notify-out"
+  NOTIFICATIONS=FALSE notify "Title" "Message"
+  [ ! -f "$BATS_TEST_TMPDIR/notify-out" ]
+}
+
+@test "show_banner is silent and successful when stdout is not a tty" {
+  SHOW_BANNER=TRUE
+  out="$(show_banner)"
+  [ -z "$out" ]
+}
+
+# --- _bool_default ---
+
+@test "_bool_default normalizes truthy/falsy inputs and applies defaults" {
+  [ "$(_bool_default "true" FALSE)" = "TRUE" ]
+  [ "$(_bool_default "Y" FALSE)" = "TRUE" ]
+  [ "$(_bool_default "1" FALSE)" = "TRUE" ]
+  [ "$(_bool_default "no" TRUE)" = "FALSE" ]
+  [ "$(_bool_default "F" TRUE)" = "FALSE" ]
+  [ "$(_bool_default "0" TRUE)" = "FALSE" ]
+  [ "$(_bool_default "" TRUE)" = "TRUE" ]
+  [ "$(_bool_default "garbage" FALSE)" = "FALSE" ]
+}
+
+# --- save_configuration ---
+
+@test "save_configuration writes all wizard values with 600 perms" {
+  __WZ_SUDO=TRUE __WZ_BACKGROUND=FALSE __WZ_QUIET=TRUE __WZ_SHOW_BANNER=FALSE __WZ_NOTIFICATIONS=TRUE
+  save_configuration
+  [ "$(file_mode "$CONFIGURATION_FILE")" = "600" ]
+  grep -q '^readonly SUDO=TRUE$' "$CONFIGURATION_FILE"
+  grep -q '^readonly BACKGROUND=FALSE$' "$CONFIGURATION_FILE"
+  grep -q '^readonly QUIET=TRUE$' "$CONFIGURATION_FILE"
+  grep -q '^readonly SHOW_BANNER=FALSE$' "$CONFIGURATION_FILE"
+  grep -q '^readonly NOTIFICATIONS=TRUE$' "$CONFIGURATION_FILE"
+  # no template placeholders left behind
+  ! grep -q '__' "$CONFIGURATION_FILE"
+}


### PR DESCRIPTION
## Fixed
- `service status` matched launchd labels as a regex; now exact (`grep -F`).
- Config validation fails closed when file permissions cannot be determined.
- After `Login failed`, the error points at `delete-secret` so a mistyped stored password is not silently reused.
- (Tap-side, already deployed) brew wrapper resolves via the stable `opt` path so login services survive `brew upgrade`.

## Added
- Coverage across the entire application: 71 bats tests (up from 29) — CLI dispatch, status/stop scan logic, config safety, log selection, notify/banner gating, setup templating, secrets backend selection, service install/uninstall/status, helper parsing. Runs on macOS + Ubuntu in CI.