### PR TITLE
Restructure README; add LICENSE and CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [Unreleased]
+
+### Added
+- `LICENSE` file (MIT — previously only claimed in the README) and
+  `CONTRIBUTING.md` with the PR/CI workflow and development setup.
+
+### Changed
+- README restructured: badges, table of contents, scannable feature list,
+  quick start, usage examples, and a roadmap section.
+
+---
+
 ## [v3.5.1] — 2026-06-13
 ### Review & Coverage Update
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to VPN Up for OpenConnect
+
+Thanks for considering a contribution! This project is small and security-sensitive, so the bar is simple but firm.
+
+## Workflow
+
+- `main` is locked — all changes land via pull request.
+- CI must be green before merge. Every PR runs:
+  - **shellcheck** — `shellcheck --shell=bash --external-sources vpn-up.command *.sh`
+  - **bats test suite** — `bats tests/` (runs on both macOS and Ubuntu; mind GNU vs BSD differences in `stat`, `ps`, `sed`)
+  - **gitleaks** — secret scanning; never commit credentials, even in test fixtures
+
+## Development setup
+
+```bash
+# macOS
+brew install bash shellcheck bats-core xmlstarlet openconnect
+
+# Debian / Ubuntu
+sudo apt install bash shellcheck bats xmlstarlet openconnect openssl
+```
+
+Run the checks locally before pushing:
+
+```bash
+shellcheck --shell=bash --external-sources vpn-up.command *.sh completions/vpn-up.bash
+bats tests/
+```
+
+## Guidelines
+
+- **Tests required**: behavior changes need a matching test in `tests/*.bats`. Network, sudo, keychain, and launchd/systemd interactions are stubbed in tests — see existing files for the pattern.
+- **Bash ≥ 4**, no `eval`, secrets never on command lines or in exported environment variables, user files created with `600`/`700` permissions.
+- Security-sensitive areas (secrets storage, sudo handling, TLS validation, hooks) get extra scrutiny in review — explain your reasoning in the PR description.
+- **Vulnerabilities**: please report privately via [SECURITY.md](SECURITY.md), not as public issues.
+
+## Releases (maintainer)
+
+Publishing a GitHub release automatically updates the Homebrew tap formula — no manual steps.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2026 Sorin-Doru Ipate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # VPN Up for OpenConnect
 
+> Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
+
+[![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/sorinipate/vpn-up-for-openconnect)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![License](https://img.shields.io/github/license/sorinipate/vpn-up-for-openconnect)](LICENSE)
+![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)
+
 ```text
     ╔═════════════════════════════════════════════════════════════════╗
     ║                                                                 ║
@@ -14,73 +21,58 @@
     ╚═════════════════════════════════════════════════════════════════╝
 ```
 
-## Secure Command-Line Client for Cisco AnyConnect (macOS & Linux)
+```console
+$ vpn-up start "Frankfurt VPN"
+Starting the Frankfurt VPN on frankfurt.simplica.com using Cisco AnyConnect ...
+Connecting with Two-Factor Authentication (2FA) from Duo (PUSH) ...
+Connected to Frankfurt VPN
 
-**VPN Up for OpenConnect** is a modern, secure, and user-friendly Bash-based wrapper around `openconnect`, designed to simplify VPN connections while following best practices for security and maintainability.
-
-This project is intended for **legitimate and authorized VPN access only**.
-
----
-
-## 🚀 Features
-
-### 🔐 Security First
-- **No plaintext passwords**
-- Secure storage via:
-  - macOS **Keychain**
-  - Linux **Secret Service**
-  - OpenSSL-encrypted vault fallback (AES-256-CBC + PBKDF2)
-- Automatic migration of legacy plaintext passwords
-- The sudo password is never stored; passwordless operation via a scoped sudoers rule (see below)
-
-### 🧠 Modern Architecture
-- Requires **Bash ≥ 4**
-- Fully modular codebase
-- Safe command execution (no `eval`)
-- Robust error handling and diagnostics
-
-### 🔑 VPN & Authentication
-- Multiple VPN profiles via XML
-- Supported protocols:
-  - Cisco AnyConnect (default)
-  - Juniper Network Connect
-  - Palo Alto GlobalProtect
-  - Pulse Secure
-- Duo 2FA support:
-  - `push`, `phone`, `sms`, or 6-digit passcode
-  - `passcode` in the profile prompts for the one-time code at connect time
-  - Empty 2FA field allows gateway auto-push
-- Correct handling of **AuthGroup** (realm) selection
-
-### 🌍 Cross-Platform
-- macOS (Apple Silicon & Intel)
-- Linux (Debian/Ubuntu/RHEL/Fedora)
-- Background or foreground execution
-- Split routing handled by OpenConnect
-
-### 🎨 User Experience
-- Interactive profile selection
-- Setup wizard
-- ASCII banner (shown when interactive)
-- Clear, color-coded output
-- Diagnostic command (`doctor`)
+$ vpn-up status
+VPN is running (PID: 88933)
+  Profile : Frankfurt VPN
+  Gateway : frankfurt.simplica.com
+  Since   : 2026-06-12 22:49:14
+  Uptime  : 08:47
+```
 
 ---
 
-## 📋 Requirements
+## 📑 Table of Contents
 
-### Mandatory
-- **Bash ≥ 4**
-- `openconnect`
-- `xmlstarlet`
-
-### Optional (recommended)
-- `openssl` (for encrypted vault fallback)
-- `secret-tool` (Linux keyring)
+- [Key Features](#-key-features)
+- [Prerequisites & Installation](#-prerequisites--installation)
+- [Quick Start](#-quick-start)
+- [Usage](#-usage)
+  - [Commands](#commands)
+  - [Run as a login service](#run-as-a-login-service-auto-reconnect)
+  - [Hooks](#hooks)
+  - [Shell completion](#shell-completion)
+  - [Secrets management](#secrets-management)
+  - [Passwordless sudo](#passwordless-sudo-optional)
+  - [Certificate pinning](#certificate-pinning)
+  - [Diagnostics](#diagnostics)
+- [Configuration](#-configuration)
+- [Roadmap](#-roadmap)
+- [Contributing & License](#-contributing--license)
 
 ---
 
-## 🛠 Installation
+## 🌟 Key Features
+
+- **No plaintext passwords** — secrets live in the macOS **Keychain**, Linux **Secret Service**, or an AES-256-CBC + PBKDF2 OpenSSL vault; legacy plaintext is migrated and scrubbed automatically
+- **Fail-closed server identity** — `pin-sha256` certificate pinning with a one-command pin fetch, or strict system trust-store validation
+- **Scriptable CLI** — connect by profile name with zero prompts (`vpn-up start "Work VPN"`)
+- **Login service with auto-reconnect** — launchd (macOS) / systemd (Linux) supervision; reconnects when the tunnel drops
+- **Lifecycle hooks** — run your own scripts on connect/disconnect (mount shares, switch proxies)
+- **Duo 2FA** — `push`, `phone`, `sms`, or one-time passcodes prompted at connect time
+- **Guided profile management** — `add-profile` / `remove-profile` wizards handle XML, secrets, pins, and services in one step
+- **Desktop notifications** on connect/disconnect (Notification Center / `notify-send`)
+- **Bash/zsh tab completion** for commands and profile names
+- **Hardened & tested** — 71 tests on macOS + Ubuntu in CI, shellcheck-clean, secret scanning, modern Bash (≥ 4), no `eval`
+
+---
+
+## 📋 Prerequisites & Installation
 
 ### Homebrew (macOS / Linux — recommended)
 
@@ -89,30 +81,30 @@ brew tap sorinipate/vpn-up
 brew install vpn-up
 ```
 
-Installs the `vpn-up` command with all dependencies (modern Bash,
-openconnect, xmlstarlet) and bash completion. Your data stays in
-`~/.config/vpn-up` either way.
+Installs the `vpn-up` command with all dependencies (modern Bash, openconnect, xmlstarlet) and bash completion. Your data stays in `~/.config/vpn-up` either way.
 
 ### Manual — macOS (Apple Silicon / Intel)
 
-macOS ships with Bash 3.2. Install modern Bash:
+macOS ships with Bash 3.2. Install modern Bash and the dependencies:
 
 ```bash
 brew install bash openconnect xmlstarlet
 ```
 
 Ensure Homebrew Bash is first in your PATH:
+
 ```bash
 echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zprofile
 exec $SHELL -l
 ```
 
-Or hard-wire the shebang in `vpn-up.command`:
-```bash
-#!/opt/homebrew/bin/bash
-```
+Then clone and run:
 
----
+```bash
+git clone https://github.com/sorinipate/vpn-up-for-openconnect.git
+cd vpn-up-for-openconnect
+chmod +x vpn-up.command
+```
 
 ### Manual — Linux
 
@@ -127,32 +119,127 @@ sudo yum install bash openconnect xmlstarlet openssl
 sudo dnf install bash openconnect xmlstarlet openssl
 ```
 
+Optional (recommended): `secret-tool` for Secret Service keyring storage.
+
 ---
 
-## ⚙️ Setup
+## 🚀 Quick Start
 
 ```bash
-chmod +x vpn-up.command
-./vpn-up.command setup
+vpn-up setup          # one-time configuration wizard
+vpn-up add-profile    # guided profile creation (+ password, + certificate pin)
+vpn-up start          # connect (interactive menu)
 ```
 
-The setup wizard will:
-- Create configuration files
-- Validate dependencies
-- Prepare secure storage backends
+> Manual installs: use `./vpn-up.command` instead of `vpn-up` throughout.
 
 ---
 
-## 📁 Configuration
+## ▶️ Usage
 
-All user state (config, profiles, secrets vault, logs, PID files) lives in
-**`~/.config/vpn-up`** (override with `VPN_UP_HOME` or `XDG_CONFIG_HOME`),
-so updating or deleting the program directory never touches your data.
-Legacy files from the old in-repo `config/` directory are migrated
-automatically on first run.
+### Commands
 
-### Main Config
-`~/.config/vpn-up/vpn-up.command.config`
+```bash
+vpn-up start                       # interactive profile menu
+vpn-up start "Frankfurt VPN"       # connect directly (scriptable)
+vpn-up list                        # list configured profiles
+vpn-up add-profile                 # guided profile creation (+ secret, + pin)
+vpn-up remove-profile "Old VPN"    # remove profile + secret + logs + service
+vpn-up status                      # profile, gateway, uptime
+vpn-up logs -f                     # follow the connection log
+vpn-up stop                        # stop the VPN (or: stop "Frankfurt VPN")
+```
+
+Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so `status`, `stop`, and `logs` are profile-aware.
+
+### Run as a login service (auto-reconnect)
+
+```bash
+vpn-up service install "Frankfurt VPN"    # connect at login, reconnect on drop
+vpn-up service status
+vpn-up service uninstall "Frankfurt VPN"
+```
+
+Uses a launchd user agent on macOS and a systemd user unit on Linux; the service manager supervises openconnect in the foreground and relaunches it if the tunnel drops (30s throttle). Requirements:
+
+- the [passwordless sudoers rule](#passwordless-sudo-optional) — there is no TTY to type a sudo password into
+- the profile's password stored in the secrets backend
+- a non-interactive 2FA method (`push`, `phone`, `sms` — not `passcode`)
+
+### Hooks
+
+Drop executable scripts into `~/.config/vpn-up/hooks/connected.d/` or `~/.config/vpn-up/hooks/disconnected.d/` and they run (in name order) when a tunnel comes up or goes down. Hooks receive `VPN_EVENT`, `VPN_NAME`, and `VPN_HOST` in their environment (never the password). Because hooks are executable code, a hook is **skipped unless it is owned by you and not group/world-writable** — same rule as the config file. Hook failures are reported but never block the VPN.
+
+```bash
+mkdir -p ~/.config/vpn-up/hooks/connected.d
+cat > ~/.config/vpn-up/hooks/connected.d/10-hello <<'EOF'
+#!/bin/sh
+echo "$(date): $VPN_NAME up ($VPN_HOST)" >> "$HOME/vpn-history.log"
+EOF
+chmod 700 ~/.config/vpn-up/hooks/connected.d/10-hello
+```
+
+### Shell completion
+
+Homebrew installs completion automatically. For manual installs:
+
+```bash
+# bash (~/.bashrc)
+source /path/to/vpn-up-for-openconnect/completions/vpn-up.bash
+
+# zsh (~/.zshrc)
+autoload -U +X bashcompinit && bashcompinit
+source /path/to/vpn-up-for-openconnect/completions/vpn-up.bash
+```
+
+Completes commands and profile names (spaces handled).
+
+### Secrets management
+
+```bash
+vpn-up set-secret "Frankfurt VPN" password
+vpn-up delete-secret "Frankfurt VPN" password
+```
+
+Passwords are stored in the OS keychain/keyring (or an encrypted vault as fallback) — never in files, never in the process table, never exported to child processes.
+
+### Passwordless sudo (optional)
+
+`openconnect` needs root. By default you'll get the normal `sudo` prompt. Never store your sudo password anywhere; if you want non-interactive runs, grant passwordless sudo for `openconnect` **only**:
+
+```bash
+# macOS (Homebrew):
+echo "$USER ALL=(root) NOPASSWD: /opt/homebrew/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
+# Linux:
+echo "$USER ALL=(root) NOPASSWD: /usr/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
+sudo chmod 440 /etc/sudoers.d/vpn-up
+sudo visudo -cf /etc/sudoers.d/vpn-up   # validate
+```
+
+> Verify the `openconnect` path with `command -v openconnect`. Keep the rule scoped to the one binary — do not add broad commands like `kill` here. Stopping the VPN will still ask for your sudo password; that's intentional.
+
+### Certificate pinning
+
+```bash
+vpn-up pin vpn.example.com          # print the pin
+vpn-up pin --save "Frankfurt VPN"   # write it into the profile
+```
+
+Prints the gateway's `pin-sha256:...` value for `<serverCertificate>`, or saves it into the profile directly with `--save`. If no pin is configured, the gateway's certificate **must** validate against the system trust store or the connection is refused (fail closed). Legacy SHA1 pins still work but print a deprecation warning. Verify any pin out-of-band with your VPN administrator before trusting it.
+
+### Diagnostics
+
+```bash
+vpn-up doctor
+```
+
+---
+
+## ⚙️ Configuration
+
+All user state (config, profiles, secrets vault, logs, PID files) lives in **`~/.config/vpn-up`** (override with `VPN_UP_HOME` or `XDG_CONFIG_HOME`), so updating or deleting the program directory never touches your data. Legacy files from the old in-repo `config/` directory are migrated automatically on first run.
+
+### Main config — `~/.config/vpn-up/vpn-up.command.config`
 
 ```bash
 readonly QUIET=TRUE          # openconnect output verbosity
@@ -162,15 +249,11 @@ readonly NOTIFICATIONS=TRUE  # desktop notification on connect/disconnect
 readonly ENCRYPTION_ENABLED=TRUE
 ```
 
-> ⚠️ `ENCRYPTION_KEY` is intentionally ignored.  
-> OS keychain/keyring is always preferred.  
-> The OpenSSL vault prompts for a passphrase when needed.
+> ⚠️ `ENCRYPTION_KEY` is intentionally ignored. OS keychain/keyring is always preferred. The OpenSSL vault prompts for a passphrase when needed.
 
----
+### VPN profiles — `~/.config/vpn-up/vpn-up.command.profiles`
 
-### VPN Profiles
-`~/.config/vpn-up/vpn-up.command.profiles`
-(template seeded from `config/vpn-up.command.profiles.default` on first run)
+Seeded from [config/vpn-up.command.profiles.default](config/vpn-up.command.profiles.default) on first run, or created via `vpn-up add-profile`:
 
 ```xml
 <VPNs>
@@ -187,158 +270,30 @@ readonly ENCRYPTION_ENABLED=TRUE
 </VPNs>
 ```
 
-#### Supported tag aliases
-- `username` or `user`
-- `group` or `authGroup`
-- `duoMethod` or `duo2FAMethod`
+Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time.
 
 ---
 
-## ▶️ Usage
+## 🗺 Roadmap
 
-### Basic Commands
-```bash
-./vpn-up.command start                  # interactive profile menu
-./vpn-up.command start "Frankfurt VPN"  # connect directly (scriptable)
-./vpn-up.command list                   # list configured profiles
-./vpn-up.command add-profile            # guided profile creation (+ secret, + pin)
-./vpn-up.command remove-profile "Old VPN"  # remove profile + secret + logs + service
-./vpn-up.command status                 # profile, gateway, uptime
-./vpn-up.command logs -f                # follow the connection log
-./vpn-up.command stop                   # stop the VPN (or: stop "Frankfurt VPN")
-```
+**Under consideration** (open an issue if you need one of these):
 
-Each profile keeps its own log and PID/state files under `~/.config/vpn-up`,
-so `status`, `stop`, and `logs` are profile-aware.
+- TOTP / RSA token support via openconnect's native `--token-mode`
+- HTTP/SOCKS proxy passthrough as a profile field
+- Multiple simultaneous tunnels (per-profile state files already lay the groundwork)
 
-### Run as a login service (auto-reconnect)
-```bash
-./vpn-up.command service install "Frankfurt VPN"    # connect at login, reconnect on drop
-./vpn-up.command service status
-./vpn-up.command service uninstall "Frankfurt VPN"
-```
-Uses a launchd user agent on macOS and a systemd user unit on Linux; the
-service manager supervises openconnect in the foreground and relaunches it
-if the tunnel drops (30s throttle). Requirements:
-- the passwordless sudoers rule for openconnect (see above) — there is no TTY
-  to type a sudo password into
-- the profile's password stored in the secrets backend
-- a non-interactive 2FA method (`push`, `phone`, `sms` — not `passcode`)
+**Explicitly out of scope:** Windows support, GUI.
 
-Desktop notifications fire on connect/disconnect (macOS Notification Center /
-`notify-send`); disable with `NOTIFICATIONS=FALSE` in the config.
-
-### Hooks
-
-Drop executable scripts into `~/.config/vpn-up/hooks/connected.d/` or
-`~/.config/vpn-up/hooks/disconnected.d/` and they run (in name order) when a
-tunnel comes up or goes down — mount shares, switch proxies, ping monitoring.
-Hooks receive `VPN_EVENT`, `VPN_NAME`, and `VPN_HOST` in their environment
-(never the password). Because hooks are executable code, a hook is **skipped
-unless it is owned by you and not group/world-writable** — same rule as the
-config file. Hook failures are reported but never block the VPN.
-
-```bash
-mkdir -p ~/.config/vpn-up/hooks/connected.d
-cat > ~/.config/vpn-up/hooks/connected.d/10-hello <<'EOF'
-#!/bin/sh
-echo "$(date): $VPN_NAME up ($VPN_HOST)" >> "$HOME/vpn-history.log"
-EOF
-chmod 700 ~/.config/vpn-up/hooks/connected.d/10-hello
-```
-
-### Shell completion
-```bash
-# bash (~/.bashrc)
-source /path/to/vpn-up-for-openconnect/completions/vpn-up.bash
-
-# zsh (~/.zshrc)
-autoload -U +X bashcompinit && bashcompinit
-source /path/to/vpn-up-for-openconnect/completions/vpn-up.bash
-```
-Completes commands and profile names (spaces handled).
-
-### Secrets Management
-```bash
-./vpn-up.command set-secret "Frankfurt VPN" password
-./vpn-up.command delete-secret "Frankfurt VPN" password
-```
-
-### Passwordless sudo (optional)
-
-`openconnect` needs root. By default you'll get the normal `sudo` prompt.
-Never store your sudo password anywhere; if you want non-interactive runs,
-grant passwordless sudo for `openconnect` **only**:
-
-```bash
-# macOS (Homebrew):
-echo "$USER ALL=(root) NOPASSWD: /opt/homebrew/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
-# Linux:
-echo "$USER ALL=(root) NOPASSWD: /usr/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
-sudo chmod 440 /etc/sudoers.d/vpn-up
-sudo visudo -cf /etc/sudoers.d/vpn-up   # validate
-```
-
-> Verify the `openconnect` path with `command -v openconnect`. Keep the rule
-> scoped to the one binary — do not add broad commands like `kill` here.
-> Stopping the VPN will still ask for your sudo password; that's intentional.
-
-### Certificate pinning
-```bash
-./vpn-up.command pin vpn.example.com          # print the pin
-./vpn-up.command pin --save "Frankfurt VPN"   # write it into the profile
-```
-Prints the gateway's `pin-sha256:...` value for `<serverCertificate>`,
-or saves it into the profile directly with `--save`.
-If no pin is configured, the gateway's certificate **must** validate against
-the system trust store or the connection is refused (fail closed). Legacy
-SHA1 pins still work but print a deprecation warning — re-pin with the
-command above. Verify any pin out-of-band with your VPN administrator
-before trusting it.
-
-### Diagnostics
-```bash
-./vpn-up.command doctor
-```
+**Known behavior:** some AnyConnect gateways emit an initial `Unexpected 404 result from server` — this is benign if the connection proceeds successfully.
 
 ---
 
-## 🔄 Migration Notes
+## 🤝 Contributing & License
 
-- Plaintext `<password>` values in profiles are **automatically migrated** on first use
-- After migration the `<password>` tag is **blanked in the XML automatically** — plaintext never lingers on disk
-- The `<password>` field is deprecated; prefer `./vpn-up.command set-secret "<profile>" password`
-- Ensure correct `authGroup` is set to avoid login prompts
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow (PRs only, shellcheck + test suite must pass on macOS and Ubuntu).
 
----
+- 🔐 Security issues: please report privately via [SECURITY.md](SECURITY.md), not public issues
+- 📄 Full release history: [CHANGELOG.md](CHANGELOG.md)
+- ⚖️ Licensed under the [MIT License](LICENSE) — © Sorin-Doru Ipate
 
-## ⚠️ Known Behavior
-
-- Some AnyConnect gateways emit:
-  ```
-  Unexpected 404 result from server
-  ```
-  This is **benign** if the connection proceeds successfully.
-
----
-
-## 📄 License
-
-MIT License  
-© Sorin-Doru Ipate
-
----
-
-## 🙏 Acknowledgments
-
-Thanks to all contributors and users who helped test and refine this release.
-
----
-
-## 🔖 Version History
-
-See [CHANGELOG.md](CHANGELOG.md) for full release history.
-
----
-
-**This project is production-ready, secure, and actively maintained.**
+Thanks to all contributors and users who helped test and refine this project.


### PR DESCRIPTION
- README reorganized: badges, terminal preview, TOC, scannable features, Homebrew-first install, quick start, usage, roadmap, contributing/license footer. All command blocks unchanged from their verified forms.
- Adds the missing MIT `LICENSE` file (README claimed MIT; repo showed no license) and `CONTRIBUTING.md` (PR-only workflow, CI requirements, dev setup, security reporting).
- Docs-only: no release.