### PR TITLE
First-run usability: offer add-profile, drop dead SUDO setting, display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
   `CONTRIBUTING.md` with the PR/CI workflow and development setup.
 
 ### Changed
+- First run of `start` with no profiles now offers the `add-profile` wizard
+  interactively instead of dead-ending into "edit the XML template by hand"
+  (scripts and service mode still get the template-seeding behavior).
+- Setup wizard: removed the "Use sudo?" question — the `SUDO` config value
+  has been dead since v3.0.0 (nothing reads it); all wizard prompts now use
+  the `[Y/n]` style (y/n/true/false all accepted, as before).
+- User-facing messages and usage text now say `vpn-up` (matching the
+  Homebrew command) instead of the internal `vpn-up.command` name; data file
+  names and the Keychain namespace are unchanged.
 - README restructured: badges, table of contents, scannable feature list,
   quick start, usage examples, and a roadmap section.
 

--- a/core.sh
+++ b/core.sh
@@ -60,11 +60,27 @@ start() {
   load_config
   print_warning "Loaded configuration from %s ...\n" "$CONFIGURATION_FILE"
 
-  # Seed the profiles template on first run, then ask the user to fill it in.
-  if [ ! -f "$PROFILES_FILE" ] && [ -f "${PROGRAM_PATH}/config/${PROGRAM_NAME}.profiles.default" ]; then
-    ( umask 077; cp "${PROGRAM_PATH}/config/${PROGRAM_NAME}.profiles.default" "$PROFILES_FILE" )
-    print_warning "Created profile template at %s\nEdit it with your VPN details, then run start again.\n" "$PROFILES_FILE"
-    exit 1
+  # First run with no profiles: offer the guided wizard when interactive;
+  # fall back to seeding the XML template for scripts/services.
+  if [ ! -f "$PROFILES_FILE" ] || [ -z "$(profile_names_raw)" ]; then
+    if [ -t 0 ] && [ -z "${VPN_UP_SERVICE:-}" ]; then
+      print_warning "No VPN profiles yet.\n"
+      local _add=""
+      read -r -p "Add your first profile now? [Y/n]: " _add
+      case "$_add" in
+        n|N|no|NO)
+          print_warning "You can add one later with: %s add-profile\n" "${DISPLAY_NAME}"
+          exit 1 ;;
+        *)
+          add_profile_wizard || exit 1 ;;
+      esac
+    else
+      if [ ! -f "$PROFILES_FILE" ] && [ -f "${PROGRAM_PATH}/config/${PROGRAM_NAME}.profiles.default" ]; then
+        ( umask 077; cp "${PROGRAM_PATH}/config/${PROGRAM_NAME}.profiles.default" "$PROFILES_FILE" )
+        print_warning "Created profile template at %s\nEdit it with your VPN details (or run '%s add-profile'), then run start again.\n" "$PROFILES_FILE" "${DISPLAY_NAME}"
+      fi
+      exit 1
+    fi
   fi
   check_file_existence "$PROFILES_FILE" "Profiles"
 
@@ -78,11 +94,11 @@ start() {
   fi
 
   if any_vpn_running; then
-    print_warning "Already connected to a VPN! Run '%s status' or '%s stop' first.\n" "${PROGRAM_NAME}" "${PROGRAM_NAME}"
+    print_warning "Already connected to a VPN! Run '%s status' or '%s stop' first.\n" "${DISPLAY_NAME}" "${DISPLAY_NAME}"
     exit 1
   fi
 
-  print_primary "Starting ${PROGRAM_NAME} ...\n"
+  print_primary "Starting ${DISPLAY_NAME} ...\n"
 
   if [ -n "$requested" ]; then
     # Non-interactive: profile named on the command line
@@ -128,7 +144,7 @@ start() {
       print_danger "Failed to connect! Last log lines from %s:\n" "${LOG_FILE_PATH}"
       tail -n 15 "$LOG_FILE_PATH" 2>/dev/null || true
       if grep -q "Login failed" "$LOG_FILE_PATH" 2>/dev/null; then
-        print_warning "If the stored password is wrong, reset it with: %s delete-secret '%s' password\n" "${PROGRAM_NAME}" "${VPN_NAME}"
+        print_warning "If the stored password is wrong, reset it with: %s delete-secret '%s' password\n" "${DISPLAY_NAME}" "${VPN_NAME}"
       fi
       notify "VPN Up" "Failed to connect to ${VPN_NAME:-VPN}"
     fi
@@ -180,7 +196,7 @@ connect() {
   if [ -n "$SERVER_CERTIFICATE" ]; then
     case "$SERVER_CERTIFICATE" in
       pin-sha256:*) : ;;
-      *) print_warning "serverCertificate uses a legacy (SHA1) pin; SHA1 is deprecated. Run '%s pin %s' to get a pin-sha256 value.\n" "${PROGRAM_NAME}" "${VPN_HOST}" ;;
+      *) print_warning "serverCertificate uses a legacy (SHA1) pin; SHA1 is deprecated. Run '%s pin %s' to get a pin-sha256 value.\n" "${DISPLAY_NAME}" "${VPN_HOST}" ;;
     esac
   else
     if ! verify_gateway_cert "${VPN_HOST}"; then

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -52,7 +52,7 @@ doctor() {
   echo
   echo "Config preview:"
   if [ -f "$CONFIGURATION_FILE" ]; then
-    grep -E '^(readonly (SUDO|BACKGROUND|QUIET|SHOW_BANNER|NOTIFICATIONS|ENCRYPTION_ENABLED))' "$CONFIGURATION_FILE" || true
+    grep -E '^(readonly (BACKGROUND|QUIET|SHOW_BANNER|NOTIFICATIONS|ENCRYPTION_ENABLED))' "$CONFIGURATION_FILE" || true
   else
     echo "  (no config yet; run ./vpn-up.command setup)"
   fi

--- a/logging.sh
+++ b/logging.sh
@@ -1,5 +1,10 @@
 # logging.sh - simple logging helpers
 
+# Name shown in user-facing messages and hints. PROGRAM_NAME stays the
+# internal identifier (data file names, slugs, Keychain namespace) and must
+# never change; brew users invoke the command as plain `vpn-up`.
+DISPLAY_NAME="${DISPLAY_NAME:-${PROGRAM_NAME%.command}}"
+
 # Legacy single-connection paths; start() switches these to per-profile
 # paths via set_profile_paths once a profile is selected.
 PID_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.pid"

--- a/network.sh
+++ b/network.sh
@@ -64,7 +64,7 @@ pin_save() {
 print_pin_instructions() {
   local host="$1"
   print_warning "To pin this gateway's certificate, run:\n"
-  print_warning "  %s pin %s\n" "${PROGRAM_NAME}" "${host}"
+  print_warning "  %s pin %s\n" "${DISPLAY_NAME}" "${host}"
   print_warning "then put the printed pin-sha256:... value in <serverCertificate> for this profile.\n"
   print_warning "Only do this if you have verified the certificate is the gateway's real one.\n"
 }

--- a/profiles.sh
+++ b/profiles.sh
@@ -74,7 +74,7 @@ migrate_or_fetch_password() {
   fi
   if [ -z "$s" ]; then
     if [ -n "${VPN_UP_SERVICE:-}" ]; then
-      print_danger "No stored password for '%s' and service mode cannot prompt. Store one first: %s set-secret '%s' password\n" "${VPN_NAME}" "${PROGRAM_NAME}" "${VPN_NAME}"
+      print_danger "No stored password for '%s' and service mode cannot prompt. Store one first: %s set-secret '%s' password\n" "${VPN_NAME}" "${DISPLAY_NAME}" "${VPN_NAME}"
       return 1
     fi
     read -r -s -p "Enter password for ${VPN_USER}@${VPN_HOST}: " s; echo

--- a/service.sh
+++ b/service.sh
@@ -100,7 +100,7 @@ _service_preflight() {
     print_warning "No passwordless sudo detected. Service mode requires a sudoers rule for openconnect (see README); the service will fail until it exists.\n"
   fi
   if [ -z "$(secrets_get "$profile" "password" 2>/dev/null)" ]; then
-    print_warning "No stored password for '%s'. Store one first: %s set-secret '%s' password\n" "$profile" "${PROGRAM_NAME}" "$profile"
+    print_warning "No stored password for '%s'. Store one first: %s set-secret '%s' password\n" "$profile" "${DISPLAY_NAME}" "$profile"
   fi
   local duo
   duo="$(xmlstarlet sel -t -m "//VPN[name=$(xpath_literal "$profile")]" -v 'duo2FAMethod | duoMethod' "$PROFILES_FILE" 2>/dev/null)"
@@ -113,7 +113,7 @@ _service_preflight() {
 
 service_install() {
   local profile="$1"
-  [ -n "$profile" ] || { echo "Usage: ${PROGRAM_NAME} service install <profile>" >&2; return 1; }
+  [ -n "$profile" ] || { echo "Usage: ${DISPLAY_NAME} service install <profile>" >&2; return 1; }
   _service_preflight "$profile" || return 1
   local target; target="$(_service_path_for "$profile")"
   if [ "$(uname)" = "Darwin" ]; then
@@ -122,7 +122,7 @@ service_install() {
     launchctl unload "$target" 2>/dev/null || true
     if launchctl load -w "$target"; then
       print_success "Installed and loaded launch agent: %s\n" "$target"
-      print_warning "The VPN will now connect at login and auto-reconnect if it drops. Remove with: %s service uninstall '%s'\n" "${PROGRAM_NAME}" "$profile"
+      print_warning "The VPN will now connect at login and auto-reconnect if it drops. Remove with: %s service uninstall '%s'\n" "${DISPLAY_NAME}" "$profile"
     else
       print_danger "Wrote %s but could not load it; load manually with: launchctl load -w '%s'\n" "$target" "$target"
       return 1
@@ -146,7 +146,7 @@ service_install() {
 
 service_uninstall() {
   local profile="$1"
-  [ -n "$profile" ] || { echo "Usage: ${PROGRAM_NAME} service uninstall <profile>" >&2; return 1; }
+  [ -n "$profile" ] || { echo "Usage: ${DISPLAY_NAME} service uninstall <profile>" >&2; return 1; }
   local target; target="$(_service_path_for "$profile")"
   if [ ! -f "$target" ]; then
     print_warning "No service installed for '%s' (%s).\n" "$profile" "$target"
@@ -159,7 +159,7 @@ service_uninstall() {
   fi
   rm -f "$target"
   print_success "Removed service for '%s'.\n" "$profile"
-  print_warning "If the VPN is still connected, stop it with: %s stop '%s'\n" "${PROGRAM_NAME}" "$profile"
+  print_warning "If the VPN is still connected, stop it with: %s stop '%s'\n" "${DISPLAY_NAME}" "$profile"
 }
 
 service_status() {

--- a/setup.sh
+++ b/setup.sh
@@ -23,12 +23,8 @@ readonly WARNING="\x1b[35;1m"
 readonly DANGER="\x1b[31;1m"
 readonly RESET="\x1b[0m"
 
-# CORE
-readonly SUDO=__SUDO__
-#        ├ TRUE
-#        └ FALSE
-# NOTE: The sudo password is never stored anywhere. For passwordless operation,
-# add a scoped sudoers rule for openconnect (see README).
+# NOTE: openconnect runs via sudo; the sudo password is never stored anywhere.
+# For passwordless operation, add a scoped sudoers rule (see README).
 
 # OPENCONNECT OPTIONS
 readonly BACKGROUND=__BACKGROUND__
@@ -51,7 +47,6 @@ readonly NOTIFICATIONS=__NOTIFICATIONS__
 # ENCRYPTION
 readonly ENCRYPTION_ENABLED=TRUE  # Toggle affects only file fallback; keychain/keyring are preferred.
 CFG
-  sed -i.bak "s/__SUDO__/${__WZ_SUDO}/" "${tmp}"
   sed -i.bak "s/__BACKGROUND__/${__WZ_BACKGROUND}/" "${tmp}"
   sed -i.bak "s/__QUIET__/${__WZ_QUIET}/" "${tmp}"
   sed -i.bak "s/__SHOW_BANNER__/${__WZ_SHOW_BANNER}/" "${tmp}"
@@ -110,16 +105,16 @@ add_profile_wizard() {
     || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
   print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
 
-  read -r -p "Store the VPN password now? (TRUE/FALSE) [TRUE]: " _in_pw
+  read -r -p "Store the VPN password now? [Y/n]: " _in_pw
   if [ "$(_bool_default "${_in_pw}" "TRUE")" = TRUE ]; then
     local _p
     read -r -s -p "Enter password for ${user}@${host}: " _p; echo
     [ -n "$_p" ] && secrets_set "$name" "password" "$_p" && print_success "Password stored securely.\n"
   fi
 
-  read -r -p "Fetch and save the gateway certificate pin now? (TRUE/FALSE) [TRUE]: " _in_pin
+  read -r -p "Fetch and save the gateway certificate pin now? [Y/n]: " _in_pin
   if [ "$(_bool_default "${_in_pin}" "TRUE")" = TRUE ]; then
-    pin_save "$name" || print_warning "Pin not saved; you can retry later with: %s pin --save '%s'\n" "${PROGRAM_NAME}" "$name"
+    pin_save "$name" || print_warning "Pin not saved; you can retry later with: %s pin --save '%s'\n" "${DISPLAY_NAME}" "$name"
   fi
 }
 
@@ -127,7 +122,7 @@ add_profile_wizard() {
 # per-profile pid/state/log files, and any installed login service.
 remove_profile() {
   local name="$1"
-  [ -n "$name" ] || { echo "Usage: ${PROGRAM_NAME} remove-profile <profile>" >&2; return 1; }
+  [ -n "$name" ] || { echo "Usage: ${DISPLAY_NAME} remove-profile <profile>" >&2; return 1; }
   if ! profile_exists "$name"; then
     print_danger "Unknown profile '%s'.\n" "$name"
     return 1
@@ -136,7 +131,7 @@ remove_profile() {
   local slug; slug="$(profile_slug "$name")"
   local pidfile="${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.pid"
   if [ -f "$pidfile" ] && is_openconnect_pid "$(cat "$pidfile")"; then
-    print_danger "Profile '%s' is currently connected; stop it first: %s stop '%s'\n" "$name" "${PROGRAM_NAME}" "$name"
+    print_danger "Profile '%s' is currently connected; stop it first: %s stop '%s'\n" "$name" "${DISPLAY_NAME}" "$name"
     return 1
   fi
 
@@ -176,19 +171,16 @@ remove_profile() {
 setup_wizard() {
   printf "%b\n" "${PRIMARY}Running first-time setup...${RESET}"
 
-  read -r -p "Use sudo for privileged operations? (TRUE/FALSE) [TRUE]: " _in_sudo
-  __WZ_SUDO="$(_bool_default "${_in_sudo}" "TRUE")"
-
-  read -r -p "Run in background after connect? (TRUE/FALSE) [TRUE]: " _in_bg
+  read -r -p "Run in background after connect? [Y/n]: " _in_bg
   __WZ_BACKGROUND="$(_bool_default "${_in_bg}" "TRUE")"
 
-  read -r -p "Quiet output? (TRUE/FALSE) [TRUE]: " _in_quiet
+  read -r -p "Quiet openconnect output? [Y/n]: " _in_quiet
   __WZ_QUIET="$(_bool_default "${_in_quiet}" "TRUE")"
 
-  read -r -p "Show ASCII banner on start? (TRUE/FALSE) [TRUE]: " _in_banner
+  read -r -p "Show ASCII banner on start? [Y/n]: " _in_banner
   __WZ_SHOW_BANNER="$(_bool_default "${_in_banner}" "TRUE")"
 
-  read -r -p "Desktop notifications on connect/disconnect? (TRUE/FALSE) [TRUE]: " _in_notif
+  read -r -p "Desktop notifications on connect/disconnect? [Y/n]: " _in_notif
   __WZ_NOTIFICATIONS="$(_bool_default "${_in_notif}" "TRUE")"
 
   # Clean up any sudo password stored by older versions; storing it defeats

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -21,6 +21,11 @@ XML
 }
 
 @test "start with no profiles, non-tty: seeds template and exits 1" {
+  # check_dependencies needs an openconnect binary; CI runners don't have one
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+  printf '#!/bin/sh\nexit 0\n' > "$BATS_TEST_TMPDIR/bin/openconnect"
+  chmod 755 "$BATS_TEST_TMPDIR/bin/openconnect"
+  export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
   rm -f "$VPN_UP_HOME/vpn-up.command.profiles"
   # config present so the setup wizard doesn't interfere
   cat > "$VPN_UP_HOME/vpn-up.command.config" <<'EOF'

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -13,11 +13,27 @@ XML
   chmod 600 "$VPN_UP_HOME/vpn-up.command.profiles"
 }
 
-@test "no arguments prints usage" {
+@test "no arguments prints usage with the display name" {
   run "$CLI"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"Usage: vpn-up <command>"* ]]
   [[ "$output" == *"start [profile]"* ]]
+}
+
+@test "start with no profiles, non-tty: seeds template and exits 1" {
+  rm -f "$VPN_UP_HOME/vpn-up.command.profiles"
+  # config present so the setup wizard doesn't interfere
+  cat > "$VPN_UP_HOME/vpn-up.command.config" <<'EOF'
+readonly BACKGROUND=TRUE
+readonly QUIET=TRUE
+readonly SHOW_BANNER=FALSE
+readonly NOTIFICATIONS=FALSE
+EOF
+  chmod 600 "$VPN_UP_HOME/vpn-up.command.config"
+  run "$CLI" start < /dev/null
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Created profile template"* ]]
+  [ -f "$VPN_UP_HOME/vpn-up.command.profiles" ]
 }
 
 @test "unknown command prints usage" {

--- a/tests/ui_setup.bats
+++ b/tests/ui_setup.bats
@@ -59,10 +59,9 @@ EOF
 # --- save_configuration ---
 
 @test "save_configuration writes all wizard values with 600 perms" {
-  __WZ_SUDO=TRUE __WZ_BACKGROUND=FALSE __WZ_QUIET=TRUE __WZ_SHOW_BANNER=FALSE __WZ_NOTIFICATIONS=TRUE
+  __WZ_BACKGROUND=FALSE __WZ_QUIET=TRUE __WZ_SHOW_BANNER=FALSE __WZ_NOTIFICATIONS=TRUE
   save_configuration
   [ "$(file_mode "$CONFIGURATION_FILE")" = "600" ]
-  grep -q '^readonly SUDO=TRUE$' "$CONFIGURATION_FILE"
   grep -q '^readonly BACKGROUND=FALSE$' "$CONFIGURATION_FILE"
   grep -q '^readonly QUIET=TRUE$' "$CONFIGURATION_FILE"
   grep -q '^readonly SHOW_BANNER=FALSE$' "$CONFIGURATION_FILE"

--- a/vpn-up.command
+++ b/vpn-up.command
@@ -53,7 +53,7 @@ PRIMARY="\x1b[36;1m"; SUCCESS="\x1b[32;1m"; WARNING="\x1b[35;1m"; DANGER="\x1b[3
 
 print_info() {
 cat <<EOF
-Usage: $PROGRAM_NAME <command>
+Usage: ${DISPLAY_NAME} <command>
 
 Commands:
   start [profile]      Start VPN (interactive menu, or directly by profile name)
@@ -75,11 +75,11 @@ Commands:
   doctor               Diagnose environment and secret backend
 
 Examples:
-  $PROGRAM_NAME start "Work VPN"
-  $PROGRAM_NAME set-secret "Work VPN" password
-  $PROGRAM_NAME pin vpn.example.com
-  $PROGRAM_NAME pin --save "Work VPN"
-  $PROGRAM_NAME logs -f
+  ${DISPLAY_NAME} start "Work VPN"
+  ${DISPLAY_NAME} set-secret "Work VPN" password
+  ${DISPLAY_NAME} pin vpn.example.com
+  ${DISPLAY_NAME} pin --save "Work VPN"
+  ${DISPLAY_NAME} logs -f
 EOF
 }
 


### PR DESCRIPTION
- `start` with no profiles offers the `add-profile` wizard when interactive (template seeding kept for scripts/service mode, locked in by a new test).
- Removed the dead "Use sudo?" wizard question (`SUDO` config unread since v3.0.0); prompts now `[Y/n]` style.
- Usage/hints show `vpn-up` (what brew users type); internal `PROGRAM_NAME` untouched for files/slugs/Keychain namespace.

72 tests passing, shellcheck clean.