### PR TITLE
Release v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
-## [Unreleased]
+## [v3.6.0] — 2026-06-13
+### First-Run Usability & Docs Update
 
 ### Added
 - `LICENSE` file (MIT — previously only claimed in the README) and


### PR DESCRIPTION
## Summary

Promote `[Unreleased]` to `[v3.6.0] — 2026-06-13` in CHANGELOG. Covers changes merged via PRs #32–#34.

## What's in v3.6.0

- **First-run UX**: `start` with no profiles now prompts the `add-profile` wizard interactively (non-TTY/service still seeds the XML template)
- **Setup wizard**: removed dead "Use sudo?" question; all prompts now `[Y/n]` style
- **Display name**: user-facing messages say `vpn-up` (matching Homebrew) — data file names and Keychain namespace unchanged
- **MIT LICENSE** file added (GitHub now detects SPDX `MIT`)
- **CONTRIBUTING.md**: PR-only workflow, CI requirements, dev setup, security reporting
- **README**: badges, ToC, scannable feature groups, quick start, usage examples, roadmap

## Test plan

- [ ] CI green (shellcheck + bats on macOS + Ubuntu + gitleaks)
- [ ] Merge → tag `v3.6.0` → publish GitHub release → `release-tap.yml` updates Homebrew formula