### PR TITLE
SAML/SSO external-browser authentication (the SSO trap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [Unreleased]
+
+### Added
+- **SSO / external-browser authentication** for gateways that force a
+  browser-based SAML/SSO login (Okta, Azure AD, Ping Identity — typically with
+  an embedded Duo iframe). Set `<authMode>sso</authMode>` on a profile (or answer
+  the new prompt in `add-profile`) and `vpn-up` connects via OpenConnect's
+  `--external-browser`: no password is piped, the login happens in the browser,
+  and the tunnel comes up afterward. Requires openconnect ≥ 9.0 (surfaced by
+  `doctor`); supported for `anyconnect`/`gp`. SSO profiles run in the foreground
+  and cannot run as a login service (interactive session required). The browser
+  opener defaults to `open`/`xdg-open` and is overridable with
+  `VPN_UP_EXTERNAL_BROWSER` (useful on Linux, where the root/sudo process may not
+  reach the desktop session). New `AUTH` column in `vpn-up list`.
+
+---
+
 ## [v3.6.0] — 2026-06-13
 ### First-Run Usability & Docs Update
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ VPN Up is useful if you:
 - [Quick Start](#-quick-start)
 - [Usage](#-usage)
   - [Commands](#commands)
+  - [SSO / external-browser login](#sso--external-browser-login)
   - [Run as a login service](#run-as-a-login-service-auto-reconnect)
   - [Hooks](#hooks)
   - [Shell completion](#shell-completion)
@@ -95,6 +96,7 @@ VPN Up is useful if you:
 - **Four SSL VPN protocols** via [OpenConnect](https://www.infradead.org/openconnect/): Cisco **AnyConnect** (and ocserv), Juniper **Network Connect**, Palo Alto **GlobalProtect**, and **Pulse Secure**
 - **Multiple VPN profiles** — pick from an interactive menu or connect by name with zero prompts (`vpn-up start "Work VPN"`), with full **AuthGroup/realm** support
 - **Duo 2FA** — `push`, `phone`, `sms`, or one-time passcodes prompted at connect time; empty method lets the gateway auto-push
+- **SSO / external-browser login** — for gateways that force a browser-based SAML/SSO flow (Okta, Azure AD, Ping Identity, often with an embedded Duo iframe), via OpenConnect's `--external-browser` (needs openconnect ≥ 9.0)
 - **Background or foreground** execution, per your config
 
 ### Secure
@@ -228,6 +230,44 @@ vpn-up stop                        # stop the VPN (or: stop "Frankfurt VPN")
 
 Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so `status`, `stop`, and `logs` are profile-aware.
 
+### SSO / external-browser login
+
+Some gateways don't accept a username/password on the command line at all — they force a real browser window for a SAML/SSO login (Okta, Azure AD, Ping Identity), often wrapping an embedded **Duo** iframe. `vpn-up` supports this via OpenConnect's external-browser mode.
+
+Mark a profile as SSO — either answer **yes** to the "Use SSO / browser-based login?" prompt in `vpn-up add-profile`, or set `<authMode>sso</authMode>` in the profile XML:
+
+```xml
+<VPN>
+  <name>Work SSO</name>
+  <protocol>anyconnect</protocol>   <!-- anyconnect or gp; not nc -->
+  <host>vpn.example.com</host>
+  <authMode>sso</authMode>
+</VPN>
+```
+
+Then connect normally:
+
+```bash
+vpn-up start "Work SSO"
+```
+
+OpenConnect opens your browser to the identity provider; you complete the login (including Duo) there, and the tunnel comes up. Notes:
+
+- **Requires openconnect ≥ 9.0** (when `--external-browser` landed). `vpn-up doctor` reports your version and whether SSO is available.
+- **Runs in the foreground** — `BACKGROUND` is ignored, and an SSO profile **cannot run as a login service** (`service install` refuses it) because it needs an interactive desktop session. No password is stored or piped for SSO profiles.
+- **Linux + sudo caveat:** openconnect runs as root, so a root-spawned browser may not reach your desktop session. If the browser doesn't appear, point `vpn-up` at a session-aware opener:
+
+  ```bash
+  # ~/bin/vpn-up-browser  (chmod +x)
+  #!/bin/sh
+  exec sudo -u "$SUDO_USER" xdg-open "$@"
+  ```
+  ```bash
+  export VPN_UP_EXTERNAL_BROWSER="$HOME/bin/vpn-up-browser"
+  ```
+
+  `VPN_UP_EXTERNAL_BROWSER` overrides the opener command (default: `open` on macOS, `xdg-open` on Linux, or the bundled `openconnect-external-browser` helper if installed).
+
 ### Run as a login service (auto-reconnect)
 
 ```bash
@@ -342,11 +382,12 @@ Seeded from [config/vpn-up.command.profiles.default](config/vpn-up.command.profi
     <password></password>
     <duo2FAMethod>push</duo2FAMethod>
     <serverCertificate>pin-sha256:BASE64_HASH</serverCertificate>
+    <authMode>password</authMode>
   </VPN>
 </VPNs>
 ```
 
-Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time.
+Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login).
 
 ---
 

--- a/config/vpn-up.command.profiles.default
+++ b/config/vpn-up.command.profiles.default
@@ -19,6 +19,11 @@
              - sms: Sends an SMS message with a new batch of passcodes to your registered device. -->
         <duo2FAMethod options="passcode, push, phone, sms">&lt;2famethod&gt;</duo2FAMethod>
         <serverCertificate></serverCertificate> <!-- SHA1 -->
+        <!-- authMode: password (default) or sso. Use 'sso' when the gateway
+             forces a browser-based SAML/SSO login (Okta, Azure AD, Ping) with
+             an embedded Duo iframe. Requires openconnect >= 9.0; runs in the
+             foreground and cannot run as a login service. -->
+        <authMode>password</authMode>
     </VPN>
 
     <!-- VPN PROFILE 2 -->
@@ -33,6 +38,8 @@
         <!-- Duo 2FA Method options are the same as for VPN PROFILE 1 -->
         <duo2FAMethod options="passcode, push, phone, sms">&lt;2famethod&gt;</duo2FAMethod>
         <serverCertificate></serverCertificate> <!-- SHA1 -->
+        <!-- authMode options are the same as for VPN PROFILE 1 -->
+        <authMode>password</authMode>
     </VPN>
     <!-- Add more VPN profiles as needed -->
 </VPNs>

--- a/core.sh
+++ b/core.sh
@@ -108,7 +108,9 @@ start() {
       exit 1
     fi
     load_profile_fields "$requested"
-    migrate_or_fetch_password || exit 1
+    if [ "${VPN_AUTH_MODE:-password}" != sso ]; then
+      migrate_or_fetch_password || exit 1
+    fi
     connect
   else
     # Interactive profile selection (modern Bash mapfile)
@@ -121,7 +123,9 @@ start() {
       fi
       if printf "%s\n" "${vpn_names[@]}" | grep -qx -- "$option"; then
         load_profile_fields "$option"
-        migrate_or_fetch_password || exit 1
+        if [ "${VPN_AUTH_MODE:-password}" != sso ]; then
+          migrate_or_fetch_password || exit 1
+        fi
         connect
         break
       else
@@ -174,9 +178,24 @@ connect() {
   print_warning "Process ID (PID) stored in %s ...\n" "${PID_FILE_PATH}"
   print_warning "Logs file (LOG) stored in %s ...\n" "${LOG_FILE_PATH}"
 
+  # SSO / external-browser auth (Okta, Azure AD, Ping + embedded Duo): the
+  # whole login happens in a browser, so there is no password or Duo answer to
+  # pipe. It needs an interactive desktop session and openconnect >= 9.0.
+  if [ "${VPN_AUTH_MODE:-password}" = sso ]; then
+    if [ -n "${VPN_UP_SERVICE:-}" ]; then
+      print_danger "Profile '%s' uses SSO (interactive browser); it cannot run as a service.\n" "${VPN_NAME}"
+      return 1
+    fi
+    if [ "$PROTOCOL" = nc ]; then
+      print_danger "SSO (external browser) is not supported for the 'nc' protocol.\n"
+      return 1
+    fi
+    require_openconnect_sso || return 1
+  fi
+
   # Duo passcodes are one-time values; never read them from the XML —
-  # prompt at connect time instead.
-  if [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
+  # prompt at connect time instead. (Skipped for SSO: the browser handles MFA.)
+  if [ "${VPN_AUTH_MODE:-password}" != sso ] && [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
     if [ -n "${VPN_UP_SERVICE:-}" ]; then
       print_danger "Profile '%s' uses a Duo passcode, which needs interactive input; it cannot run as a service. Use push/phone/sms instead.\n" "${VPN_NAME}"
       return 1
@@ -207,7 +226,9 @@ connect() {
   fi
 
   print_primary "Starting the %s on %s using %s ...\n" "${VPN_NAME}" "${VPN_HOST}" "${PROTOCOL_DESCRIPTION}"
-  if [ -z "$VPN_DUO2FAMETHOD" ]; then
+  if [ "${VPN_AUTH_MODE:-password}" = sso ]; then
+    print_primary "Connecting via SSO (external browser) — complete the login in the window that opens ...\n"
+  elif [ -z "$VPN_DUO2FAMETHOD" ]; then
     print_warning "Connecting without 2FA (%s) ...\n" "${VPN_DUO2FAMETHOD_DESCRIPTION}"
   else
     print_primary "Connecting with Two-Factor Authentication (2FA) from Duo (%s) ...\n" "${VPN_DUO2FAMETHOD_DESCRIPTION}"
@@ -316,6 +337,18 @@ stop() {
   return "$rc"
 }
 
+# Resolve the command openconnect runs (with the SSO login URL as its argument)
+# to open the external browser. openconnect itself catches the returned token on
+# a localhost listener, so any URL opener works. Honor an explicit override,
+# then the bundled helper, then the platform default. NOTE: openconnect runs as
+# root via sudo, so on Linux a root-spawned opener may not reach the user's GUI
+# session — set VPN_UP_EXTERNAL_BROWSER to a session-aware wrapper if so.
+resolve_external_browser() {
+  if [ -n "${VPN_UP_EXTERNAL_BROWSER:-}" ]; then printf '%s' "$VPN_UP_EXTERNAL_BROWSER"; return; fi
+  if command -v openconnect-external-browser >/dev/null 2>&1; then printf 'openconnect-external-browser'; return; fi
+  [ "$(uname)" = Darwin ] && printf 'open' || printf 'xdg-open'
+}
+
 run_openconnect() {
   # Validate sudo up-front on the TTY so the prompt doesn't collide with the
   # password pipe below. For passwordless use, configure a scoped sudoers rule
@@ -333,14 +366,21 @@ run_openconnect() {
 
   # Under launchd/systemd the service manager must supervise openconnect
   # itself, so force foreground; KeepAlive/Restart provides auto-reconnect.
+  # SSO is interactive and always runs foreground too (BACKGROUND is ignored).
   local effective_background="${BACKGROUND:-FALSE}"
   [ -n "${VPN_UP_SERVICE:-}" ] && effective_background=FALSE
+  [ "${VPN_AUTH_MODE:-password}" = sso ] && effective_background=FALSE
 
   # Build argv array (no eval)
   local args=()
   args+=(--protocol="$PROTOCOL")
   args+=(--user="$VPN_USER")
-  args+=(--passwd-on-stdin)
+  if [ "${VPN_AUTH_MODE:-password}" = sso ]; then
+    # SSO: authenticate in a browser; no password is piped on stdin.
+    args+=(--external-browser="$(resolve_external_browser)")
+  else
+    args+=(--passwd-on-stdin)
+  fi
   [ "${QUIET:-FALSE}" = TRUE ] && args+=(-q)
   [ "$effective_background" = TRUE ] && args+=(--background)
   [ -n "$SERVER_CERTIFICATE" ] && args+=(--servercert="$SERVER_CERTIFICATE")
@@ -359,7 +399,24 @@ run_openconnect() {
   local stdin_lines="$VPN_PASSWD"
   [ -n "$VPN_DUO2FAMETHOD" ] && stdin_lines+=$'\n'"$VPN_DUO2FAMETHOD"
   ( umask 077; : > "$LOG_FILE_PATH" )
-  if [ "$effective_background" = TRUE ]; then
+  if [ "${VPN_AUTH_MODE:-password}" = sso ]; then
+    # SSO: openconnect opens a browser and needs the controlling TTY, so pipe
+    # NOTHING on stdin. Always foreground; capture the PID the same way as the
+    # foreground password path so status/stop work during the session.
+    write_connection_state
+    ( sleep 3
+      _pid="$(pgrep -n -x openconnect 2>/dev/null || true)"
+      if [ -n "$_pid" ]; then
+        printf '%s\n' "$_pid" > "$PID_FILE_PATH"
+        notify "VPN Up" "Connected to ${VPN_NAME}"
+        run_hooks connected "${VPN_NAME}" "${VPN_HOST}"
+      fi
+    ) &
+    sudo openconnect "${args[@]}" 2>&1 | tee -a "$LOG_FILE_PATH"
+    rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
+    notify "VPN Up" "Disconnected from ${VPN_NAME:-VPN}"
+    run_hooks disconnected "${VPN_NAME:-}" "${VPN_HOST:-}"
+  elif [ "$effective_background" = TRUE ]; then
     # The daemonized child keeps stdout open, so piping through tee would
     # hang the shell forever after openconnect backgrounds itself; write
     # straight to the log instead.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -9,6 +9,28 @@ require_bin() {
   fi
 }
 
+# Major version of the installed openconnect, or empty if unparseable.
+# `openconnect --version` prints e.g. "OpenConnect version v9.12" (some distro
+# builds drop the leading 'v').
+openconnect_major() {
+  openconnect --version 2>&1 | sed -n 's/.*[Vv]ersion v\{0,1\}\([0-9][0-9]*\)\..*/\1/p' | head -1
+}
+
+# Gate the SSO path on openconnect >= 9.0 (when --external-browser landed).
+# Lenient when the version can't be determined so it never blocks on odd builds.
+require_openconnect_sso() {
+  local major; major="$(openconnect_major)"
+  if [ -z "$major" ]; then
+    print_warning "Could not determine openconnect version; SSO (external browser) needs >= 9.0.\n"
+    return 0
+  fi
+  if [ "$major" -lt 9 ]; then
+    print_danger "SSO (external browser) needs openconnect >= 9.0; found v%s. Upgrade openconnect.\n" "$major"
+    return 1
+  fi
+  return 0
+}
+
 check_dependencies() {
   require_bin xmlstarlet "Install via: brew install xmlstarlet | apt-get install xmlstarlet"
   require_bin openconnect "Install via: brew install openconnect | apt-get install openconnect"
@@ -40,6 +62,15 @@ doctor() {
       echo "  [!!] $b MISSING"
     fi
   done
+  if command -v openconnect >/dev/null 2>&1; then
+    local _ocmaj; _ocmaj="$(openconnect_major)"
+    echo "  -    openconnect version: $(openconnect --version 2>&1 | head -1)"
+    if [ -n "$_ocmaj" ] && [ "$_ocmaj" -ge 9 ]; then
+      echo "  [OK] SSO / external browser supported (openconnect >= 9.0)"
+    else
+      echo "  [..] SSO / external browser needs openconnect >= 9.0 (detected: ${_ocmaj:-unknown})"
+    fi
+  fi
   if [ "$(uname)" = "Darwin" ]; then
     if command -v security >/dev/null 2>&1; then echo "  [OK] security (Keychain)"; else echo "  [!!] security missing"; fi
   else

--- a/profiles.sh
+++ b/profiles.sh
@@ -31,7 +31,8 @@ load_profile_fields() {
       -v "username | user" -n \
       -v "password" -n \
       -v "duo2FAMethod | duoMethod" -n \
-      -v "serverCertificate" -n "${PROFILES_FILE}"
+      -v "serverCertificate" -n \
+      -v "authMode | authmode" -n "${PROFILES_FILE}"
   )
   VPN_NAME="${fields[0]:-}"
   PROTOCOL="${fields[1]:-}"
@@ -41,6 +42,9 @@ load_profile_fields() {
   VPN_PASSWD="${fields[5]:-}"
   VPN_DUO2FAMETHOD="${fields[6]:-}"
   SERVER_CERTIFICATE="${fields[7]:-}"
+  # Authentication mode: 'sso' (browser-based SAML/SSO) or 'password' (default).
+  VPN_AUTH_MODE="$(printf '%s' "${fields[8]:-password}" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$VPN_AUTH_MODE" ]; then VPN_AUTH_MODE=password; fi
 
   # Intentionally NOT exported: these are read only by functions in this
   # shell, and exporting would copy the password into the environment of
@@ -107,10 +111,11 @@ list_profiles() {
       -v name -o $'\t' \
       -v protocol -o $'\t' \
       -v host -o $'\t' \
-      -v 'duo2FAMethod | duoMethod' -n "$PROFILES_FILE" \
+      -v 'duo2FAMethod | duoMethod' -o $'\t' \
+      -v 'authMode | authmode' -n "$PROFILES_FILE" \
     | awk -F'\t' '
-        BEGIN { printf "%-25s %-11s %-35s %s\n", "NAME", "PROTOCOL", "HOST", "2FA" }
-        { printf "%-25s %-11s %-35s %s\n", $1, ($2==""?"-":$2), ($3==""?"-":$3), ($4==""?"-":$4) }'
+        BEGIN { printf "%-25s %-11s %-35s %-9s %s\n", "NAME", "PROTOCOL", "HOST", "2FA", "AUTH" }
+        { printf "%-25s %-11s %-35s %-9s %s\n", $1, ($2==""?"-":$2), ($3==""?"-":$3), ($4==""?"-":$4), ($5==""?"password":$5) }'
 }
 
 # shellcheck disable=SC2034  # description vars are consumed by core.sh

--- a/service.sh
+++ b/service.sh
@@ -96,6 +96,12 @@ _service_preflight() {
     print_danger "Unknown profile '%s'.\n" "$profile"
     return 1
   fi
+  local authmode
+  authmode="$(xmlstarlet sel -t -m "//VPN[name=$(xpath_literal "$profile")]" -v 'authMode | authmode' "$PROFILES_FILE" 2>/dev/null)"
+  if [ "$authmode" = sso ]; then
+    print_danger "Profile '%s' uses SSO (interactive browser); it cannot run as a login service.\n" "$profile"
+    return 1
+  fi
   if ! sudo -n -v 2>/dev/null; then
     print_warning "No passwordless sudo detected. Service mode requires a sudoers rule for openconnect (see README); the service will fail until it exists.\n"
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ CFG
 # Append a <VPN> block to the profiles file (password stays empty — secrets
 # belong in the secrets backend, set separately).
 append_profile() {
-  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6"
+  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}"
   local tmp="${PROFILES_FILE}.tmp"
   xmlstarlet ed \
     -s '/VPNs' -t elem -n VPN -v '' \
@@ -72,6 +72,7 @@ append_profile() {
     -s '/VPNs/VPN[last()]' -t elem -n password -v '' \
     -s '/VPNs/VPN[last()]' -t elem -n duo2FAMethod -v "$duo" \
     -s '/VPNs/VPN[last()]' -t elem -n serverCertificate -v '' \
+    -s '/VPNs/VPN[last()]' -t elem -n authMode -v "$authmode" \
     "${PROFILES_FILE}" > "${tmp}" && mv "${tmp}" "${PROFILES_FILE}" && chmod 600 "${PROFILES_FILE}"
 }
 
@@ -80,7 +81,7 @@ add_profile_wizard() {
     ( umask 077; printf '<VPNs>\n</VPNs>\n' > "$PROFILES_FILE" )
   fi
 
-  local name proto host group user duo
+  local name proto host group user duo authmode
   read -r -p "Profile name: " name
   [ -n "$name" ] || { print_danger "Profile name is required.\n"; return 1; }
   if profile_exists "$name"; then
@@ -99,17 +100,34 @@ add_profile_wizard() {
   [ -n "$host" ] || { print_danger "Gateway host is required.\n"; return 1; }
   read -r -p "Auth group (optional): " group
   read -r -p "Username: " user
-  read -r -p "Duo 2FA method (push/phone/sms/passcode; empty = gateway default): " duo
 
-  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" \
+  # SSO / browser-based login (Okta, Azure AD, Ping + embedded Duo). When on,
+  # credentials and MFA are entered in the browser, so skip the Duo-method and
+  # password prompts entirely.
+  authmode=password; duo=""
+  local _in_sso=""
+  read -r -p "Use SSO / browser-based login (Okta, Azure AD, Ping + Duo)? [y/N]: " _in_sso
+  if [ "$(_bool_default "${_in_sso}" "FALSE")" = TRUE ]; then
+    if [ "$proto" = nc ]; then
+      print_danger "SSO (external browser) is not supported for the 'nc' protocol.\n"
+      return 1
+    fi
+    authmode=sso
+  else
+    read -r -p "Duo 2FA method (push/phone/sms/passcode; empty = gateway default): " duo
+  fi
+
+  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" \
     || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
   print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
 
-  read -r -p "Store the VPN password now? [Y/n]: " _in_pw
-  if [ "$(_bool_default "${_in_pw}" "TRUE")" = TRUE ]; then
-    local _p
-    read -r -s -p "Enter password for ${user}@${host}: " _p; echo
-    [ -n "$_p" ] && secrets_set "$name" "password" "$_p" && print_success "Password stored securely.\n"
+  if [ "$authmode" != sso ]; then
+    read -r -p "Store the VPN password now? [Y/n]: " _in_pw
+    if [ "$(_bool_default "${_in_pw}" "TRUE")" = TRUE ]; then
+      local _p
+      read -r -s -p "Enter password for ${user}@${host}: " _p; echo
+      [ -n "$_p" ] && secrets_set "$name" "password" "$_p" && print_success "Password stored securely.\n"
+    fi
   fi
 
   read -r -p "Fetch and save the gateway certificate pin now? [Y/n]: " _in_pin

--- a/tests/sso.bats
+++ b/tests/sso.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# Tests for SAML/SSO external-browser authentication (authMode=sso).
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { printf -- "$1" "${@:2}"; }
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_success() { printf -- "$1" "${@:2}"; }
+  print_primary() { printf -- "$1" "${@:2}"; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../dependencies.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+_write_profiles() {
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>SSO VPN</name><protocol>anyconnect</protocol><host>sso.example.com</host><authGroup></authGroup><user>alice</user><password></password><duo2FAMethod></duo2FAMethod><serverCertificate></serverCertificate><authMode>sso</authMode></VPN>
+  <VPN><name>Pwd VPN</name><protocol>anyconnect</protocol><host>pwd.example.com</host><authGroup></authGroup><user>bob</user><password></password><duo2FAMethod>push</duo2FAMethod><serverCertificate></serverCertificate></VPN>
+</VPNs>
+XML
+}
+
+# --- schema: authMode is loaded and defaults to password ---
+
+@test "load_profile_fields reads authMode=sso and leaves earlier fields intact" {
+  _write_profiles
+  load_profile_fields "SSO VPN"
+  [ "$VPN_NAME" = "SSO VPN" ]
+  [ "$PROTOCOL" = "anyconnect" ]
+  [ "$VPN_HOST" = "sso.example.com" ]
+  [ "$VPN_USER" = "alice" ]
+  [ "$VPN_AUTH_MODE" = "sso" ]
+}
+
+@test "load_profile_fields defaults authMode to password when the tag is absent" {
+  _write_profiles
+  load_profile_fields "Pwd VPN"
+  [ "$VPN_AUTH_MODE" = "password" ]
+  [ "$VPN_DUO2FAMETHOD" = "push" ]
+}
+
+# --- resolve_external_browser ---
+
+@test "resolve_external_browser honors the override, else a platform default" {
+  VPN_UP_EXTERNAL_BROWSER="/opt/my-browser" run resolve_external_browser
+  [ "$output" = "/opt/my-browser" ]
+  unset VPN_UP_EXTERNAL_BROWSER
+  run resolve_external_browser
+  case "$output" in open|xdg-open|openconnect-external-browser) : ;; *) false ;; esac
+}
+
+# --- run_openconnect argv: external-browser, no password on stdin ---
+
+@test "run_openconnect (sso) passes --external-browser and never --passwd-on-stdin" {
+  local cap="$BATS_TEST_TMPDIR/argv"
+  # Capture only the openconnect invocation; succeed for sudo -v / -n -v.
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$cap"; return 0; fi; return 0; }
+  sleep() { :; }                      # don't linger on the 3s PID-capture subshell
+  tee()  { cat >/dev/null; }          # swallow logged output
+
+  VPN_NAME="SSO VPN"; PROTOCOL="anyconnect"; VPN_HOST="sso.example.com"
+  VPN_USER="alice"; VPN_GROUP=""; VPN_PASSWD=""; VPN_DUO2FAMETHOD=""
+  SERVER_CERTIFICATE=""; VPN_AUTH_MODE="sso"
+  QUIET=FALSE; BACKGROUND=TRUE        # BACKGROUND must be ignored for SSO
+  VPN_UP_EXTERNAL_BROWSER="my-opener"
+  PID_FILE_PATH="$DATA_DIR/pids/${PROGRAM_NAME}.SSO.pid"
+  STATE_FILE_PATH="$DATA_DIR/pids/${PROGRAM_NAME}.SSO.state"
+  LOG_FILE_PATH="$DATA_DIR/logs/${PROGRAM_NAME}.SSO.log"
+
+  run_openconnect
+  grep -qF -- "--external-browser=my-opener" "$cap"
+  ! grep -qF -- "--passwd-on-stdin" "$cap"
+  ! grep -qF -- "--background" "$cap"   # forced foreground
+}
+
+@test "run_openconnect (password) still passes --passwd-on-stdin and no external-browser" {
+  local cap="$BATS_TEST_TMPDIR/argv"
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$cap"; return 0; fi; return 0; }
+  sleep() { :; }
+  tee()  { cat >/dev/null; }
+
+  VPN_NAME="Pwd VPN"; PROTOCOL="anyconnect"; VPN_HOST="pwd.example.com"
+  VPN_USER="bob"; VPN_GROUP=""; VPN_PASSWD="s3cret"; VPN_DUO2FAMETHOD="push"
+  SERVER_CERTIFICATE=""; VPN_AUTH_MODE="password"
+  QUIET=FALSE; BACKGROUND=FALSE
+  PID_FILE_PATH="$DATA_DIR/pids/${PROGRAM_NAME}.Pwd.pid"
+  STATE_FILE_PATH="$DATA_DIR/pids/${PROGRAM_NAME}.Pwd.state"
+  LOG_FILE_PATH="$DATA_DIR/logs/${PROGRAM_NAME}.Pwd.log"
+
+  run_openconnect
+  grep -qF -- "--passwd-on-stdin" "$cap"
+  ! grep -qF -- "--external-browser" "$cap"
+}
+
+# --- version gate ---
+
+@test "require_openconnect_sso accepts v9+, rejects v8, is lenient when unknown" {
+  openconnect() { echo "OpenConnect version v9.12"; }
+  run require_openconnect_sso; [ "$status" -eq 0 ]
+  openconnect() { echo "OpenConnect version v8.10"; }
+  run require_openconnect_sso; [ "$status" -ne 0 ]
+  openconnect() { echo ""; }
+  run require_openconnect_sso; [ "$status" -eq 0 ]
+}
+
+@test "openconnect_major parses with and without the leading v" {
+  openconnect() { echo "OpenConnect version v9.12"; }
+  [ "$(openconnect_major)" = "9" ]
+  openconnect() { echo "OpenConnect version 8.20"; }
+  [ "$(openconnect_major)" = "8" ]
+}
+
+# --- connect()/service guards for SSO ---
+
+@test "connect refuses SSO in service mode and for the nc protocol" {
+  _write_profiles
+  set_profile_paths() { PID_FILE_PATH=x; LOG_FILE_PATH=y; STATE_FILE_PATH=z; }
+  require_openconnect_sso() { return 0; }
+  load_profile_fields "SSO VPN"
+
+  VPN_UP_SERVICE=1 run connect
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot run as a service"* ]]
+
+  PROTOCOL="nc" run connect
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not supported for the 'nc' protocol"* ]]
+}
+
+@test "service preflight rejects an SSO profile" {
+  _write_profiles
+  source "$BATS_TEST_DIRNAME/../service.sh"
+  sudo() { return 0; }
+  secrets_get() { echo ""; }
+  run _service_preflight "SSO VPN"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot run as a login service"* ]]
+}


### PR DESCRIPTION
## Summary

Adds support for gateways that force a **browser-based SAML/SSO login** (Okta, Azure AD, Ping Identity — typically with an embedded Duo iframe). Today `run_openconnect()` always pipes a password via `--passwd-on-stdin`, which can't work against SSO. This adds an explicit **`authMode = sso`** profile mode that runs OpenConnect with `--external-browser` instead: no password is piped, the login happens in the browser, and the tunnel comes up afterward.

Verified against the OpenConnect docs: `--external-browser=CMD` (openconnect ≥ 9.0) opens `CMD <sso-url>` and catches the returned token on its own localhost listener, so `open`/`xdg-open` work as the command.

## What's included

- **Schema:** `<authMode>` appended last (`password` default | `sso`) — no field-index shift; new `AUTH` column in `vpn-up list`.
- **`connect()`:** SSO branch with service-mode + `nc`-protocol guards and an openconnect ≥ 9.0 version gate; keeps cert pinning; skips Duo.
- **`run_openconnect()`:** omits `--passwd-on-stdin`, adds `--external-browser=<resolved>`, forces foreground, and pipes **nothing** to stdin so openconnect keeps the TTY. `resolve_external_browser()` honors `VPN_UP_EXTERNAL_BROWSER`, else the bundled helper, else `open`/`xdg-open`.
- **`start()`:** skips the password fetch for SSO profiles.
- **Wizard:** `add-profile` asks "Use SSO?" and skips the Duo + password prompts when yes.
- **Service guard:** `service install` refuses SSO profiles (interactive session required).
- **doctor:** prints the openconnect version and SSO availability.
- **Docs:** README Usage subsection (incl. the Linux root/sudo→GUI caveat + `VPN_UP_EXTERNAL_BROWSER` wrapper), CHANGELOG `[Unreleased]`.
- **Tests:** `tests/sso.bats` (9) — schema/default, argv built with `--external-browser` and **without** `--passwd-on-stdin`, resolver, version gate, and the connect/service guards.

## Test plan

- [ ] CI green (shellcheck + bats on macOS + Ubuntu + gitleaks)
- Local: 81 bats tests pass, shellcheck clean; smoke-tested `list` (AUTH column), `doctor` (v9.12 → SSO supported), and the `add-profile` SSO path.

## Notes / limitations (documented)

- SSO runs **foreground** (`BACKGROUND` ignored) and **can't run as a login service**.
- `nc` protocol has no SSO support; rejected early.
- Linux + sudo: a root-spawned browser may not reach the desktop session — hence the `VPN_UP_EXTERNAL_BROWSER` override.