### PR TITLE
README: fix Release/License badge token-pool errors (use static badges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/sorinipate/vpn-up-for-openconnect)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
-[![License](https://img.shields.io/github/license/sorinipate/vpn-up-for-openconnect)](LICENSE)
+[![Release](https://img.shields.io/badge/release-v3.6.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)
 
 ```text

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,11 +90,14 @@ a tag + GitHub release.
 
 1. **Land the work.** All feature/fix PRs for the version are merged to `main`
    and their entries sit under `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md).
-2. **Promote the changelog.** On a release branch, change `## [Unreleased]` to
-   `## [vX.Y.Z] — YYYY-MM-DD` and add the `### <Theme> Update` subtitle line.
+2. **Promote the changelog + bump the README badge.** On a release branch,
+   change `## [Unreleased]` to `## [vX.Y.Z] — YYYY-MM-DD` and add the
+   `### <Theme> Update` subtitle line. Also bump the static release badge in
+   [README.md](README.md) (`release-vX.Y.Z-blue`) — it's static on purpose, so
+   shields.io's GitHub token pool can't break it.
    ```bash
    git checkout -b release-vX.Y.Z
-   # edit CHANGELOG.md
+   # edit CHANGELOG.md and the README release badge
    git commit -am "Release vX.Y.Z: <theme>"
    git push -u origin release-vX.Y.Z
    ```


### PR DESCRIPTION
## Summary

The **Release** and **License** badges used shields.io's dynamic GitHub endpoints (`github/v/release`, `github/license`), which share a pool of GitHub API tokens. When that pool is rate-limited, shields renders **"Unable to select next GitHub token from pool"** instead of the value (confirmed live: the License endpoint is erroring right now).

Switched both to **static** shields badges that make no GitHub API call:
- `release-v3.6.0-blue` → links to `/releases/latest`
- `license-MIT-blue` → links to `LICENSE`

RELEASING.md step 2 now bumps the static release badge alongside the CHANGELOG, so it stays accurate each release.

## Test plan

- [ ] CI green (docs-only)
- Verified both static endpoints render (`v3.6.0`, `MIT`) with no token-pool error.