### PR TITLE
Release v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
-## [Unreleased]
+## [v3.7.0] — 2026-06-16
+### Browser-based SSO Login Update
 
 ### Added
 - **SSO / external-browser authentication** for gateways that force a

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.6.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.7.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)
 


### PR DESCRIPTION
## Summary

Cuts **v3.7.0** — the browser-based SSO feature (merged via #49).

- Promote `[Unreleased]` → `[v3.7.0] — 2026-06-16` in CHANGELOG
- Bump the static README release badge to `v3.7.0`

## What's in v3.7.0

**SSO / external-browser authentication** for gateways that force a browser-based SAML/SSO login (Okta, Azure AD, Ping Identity, typically with an embedded Duo iframe). Set `authMode=sso` on a profile and `vpn-up` connects via OpenConnect's `--external-browser` (≥ 9.0). SSO profiles run foreground, can't run as a login service, and honor `VPN_UP_EXTERNAL_BROWSER`. New `AUTH` column in `vpn-up list`; `doctor` surfaces the openconnect version + SSO availability.

## Test plan

- [ ] CI green (shellcheck + bats on macOS + Ubuntu + gitleaks)
- [ ] Merge → tag `v3.7.0` → publish release → `release-tap.yml` updates the Homebrew formula