### PR TITLE
Add PRD and ARCHITECTURE documents

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,169 @@
+# Architecture — VPN Up for OpenConnect
+
+**Last updated:** 2026-06-16 (v3.7.0)
+
+> *What* and *why* live in [PRD.md](PRD.md); this document covers *how*. Function and
+> file references are accurate as of the version above — verify against the source
+> before relying on a specific line.
+
+---
+
+## 1. Design principles
+
+1. **Wrap, don't reimplement.** OpenConnect owns tunnelling, protocols, and TLS.
+   VPN Up owns profiles, credentials, lifecycle, and ergonomics.
+2. **Secrets never leak.** No plaintext at rest, no credentials in `argv` (visible in
+   the process table) or in child-process environments, no `eval`.
+3. **Fail closed.** Unknown server identity, unsafe file permissions, or missing
+   prerequisites stop the flow rather than proceeding insecurely.
+4. **Small, modular, auditable Bash.** One concern per file; pure functions where
+   possible; everything readable in an afternoon.
+5. **Portable.** macOS + Linux, Bash ≥ 4; GNU/BSD tool differences are abstracted in helpers.
+6. **User state is sacred and isolated.** It lives outside the program directory so
+   reinstalling/cleaning the repo never touches it.
+
+## 2. High-level shape
+
+```
+              ┌─────────────────────────────────────────────┐
+   user  ───▶ │  vpn-up.command  (entry point / dispatcher)  │
+              │  • Bash≥4 guard, set -u                       │
+              │  • resolve paths, migrate legacy state        │
+              │  • source modules, dispatch subcommand        │
+              └───────────────┬─────────────────────────────-┘
+                              │ sources (in order)
+   logging.sh ─ ui.sh ─ dependencies.sh ─ encryption.sh ─ network.sh ─
+   profiles.sh ─ core.sh ─ setup.sh ─ service.sh
+                              │
+                              ▼
+        ┌───────────────┐         ┌──────────────────────────┐
+        │  profiles XML │         │  secrets backend          │
+        │ ~/.config/... │         │  Keychain / Secret Service │
+        └───────────────┘         │  / OpenSSL vault          │
+                              │    └──────────────────────────┘
+                              ▼
+                    sudo openconnect …  ──▶  tun interface + routes
+                              │
+            per-profile pid / state / log under ~/.config/vpn-up
+```
+
+## 3. Module responsibilities
+
+All modules are sourced by [vpn-up.command](vpn-up.command) in dependency order.
+
+| Module | Responsibility |
+|---|---|
+| **[vpn-up.command](vpn-up.command)** | Entry point. Bash≥4 guard, `set -u`, resolves `PROGRAM_NAME`/`PROGRAM_PATH`/`DATA_DIR`, one-time migration of legacy in-repo state, sources modules, and dispatches the subcommand `case`. Defines `DISPLAY_NAME` indirectly (via logging). |
+| **[logging.sh](logging.sh)** | Paths, print helpers (`print_primary/success/warning/danger`), portable `stat` wrappers (`file_owner_uid`, `file_mode` — GNU `-c` first, BSD `-f` fallback), `profile_slug`, per-profile path setup (`set_profile_paths`), PID helpers (`is_openconnect_pid`, `any_vpn_running`), `show_logs`. Defines `DISPLAY_NAME`. |
+| **[ui.sh](ui.sh)** | ASCII banner (`show_banner`, gated by `SHOW_BANNER` + TTY) and desktop notifications (`notify` → `osascript`/`notify-send`, gated by `NOTIFICATIONS`). |
+| **[dependencies.sh](dependencies.sh)** | `require_bin`, `check_dependencies`, `doctor`. Also `openconnect_major` / `require_openconnect_sso` (the openconnect ≥ 9.0 gate for SSO). |
+| **[encryption.sh](encryption.sh)** | Secret backend abstraction: `secrets_set/get/delete`, `secrets_backend` selection (macOS Keychain via `security -i` stdin; Linux Secret Service via `secret-tool`; OpenSSL AES-256-CBC + PBKDF2 vault fallback). Namespacing via `secrets_key`. |
+| **[network.sh](network.sh)** | Connectivity check, certificate fetch/verify (`fetch_server_pin`, `verify_gateway_cert`), pin save (`pin_save`), `print_pin_instructions`, `print_current_ip_address`. |
+| **[profiles.sh](profiles.sh)** | Profile XML read/validate: `load_profile_fields` (xmlstarlet → shell vars), `xpath_literal` (injection-safe XPath), `list_profiles`, `profile_names_raw`, `profile_exists`, password migration/scrub, protocol/2FA descriptions. |
+| **[core.sh](core.sh)** | Main flow: `start`, `connect`, `run_openconnect`, `status`, `stop`, `write_connection_state`, `run_hooks`, `assert_safe_to_source`, `load_config`, `resolve_external_browser`. |
+| **[setup.sh](setup.sh)** | Interactive wizards: `setup_wizard`, `add_profile_wizard`, `remove_profile`, `append_profile`, `save_configuration`, `_bool_default`. |
+| **[service.sh](service.sh)** | Login-service mode: launchd plist / systemd unit generation, `service_install/uninstall/status`, `_service_preflight` (rejects passcode + SSO profiles). |
+| **[completions/vpn-up.bash](completions/vpn-up.bash)** | Bash/zsh completion for commands and profile names. |
+
+## 4. Data & state layout
+
+All user state lives under **`DATA_DIR`** = `${VPN_UP_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/vpn-up}`,
+created `700`, files `600`. Legacy in-repo `config/<name>.*` files migrate here on first run.
+
+```
+~/.config/vpn-up/
+├── vpn-up.command.config        # sourced shell config (BACKGROUND, QUIET, SHOW_BANNER, NOTIFICATIONS, …)
+├── vpn-up.command.profiles      # <VPNs> XML; one <VPN> per profile
+├── vpn-up.command.secrets[.enc] # OpenSSL vault (only if that backend is in use)
+├── logs/<name>.<slug>.log       # per-profile connection log (+ service.<slug>.log)
+├── pids/<name>.<slug>.pid       # per-profile PID
+├── pids/<name>.<slug>.state     # profile/host/connected_at for `status`
+└── hooks/{connected,disconnected}.d/*   # user lifecycle scripts (must be safely owned)
+```
+
+`PROGRAM_NAME` (e.g. `vpn-up.command`) namespaces data files, slugs, and the Keychain
+namespace; `DISPLAY_NAME` (`vpn-up`) is used only in user-facing text.
+
+### Profile schema (`<VPN>`)
+`name`, `protocol`, `host`, `authGroup` (alias `group`), `user` (alias `username`),
+`password` (deprecated; migrated + blanked), `duo2FAMethod` (alias `duoMethod`),
+`serverCertificate`, `authMode` (`password` default | `sso`). `load_profile_fields`
+reads them positionally via `mapfile`, so **new fields are appended last** to avoid
+shifting indices.
+
+## 5. Key flows
+
+### 5.1 `start` → `connect` → `run_openconnect`
+1. **`start`** ensures config exists (else `setup_wizard`), loads it (`load_config`
+   after `assert_safe_to_source`), handles the no-profiles first-run, runs network +
+   already-running checks, then selects a profile (named or interactive menu).
+2. `load_profile_fields` populates shell vars. For non-SSO profiles,
+   `migrate_or_fetch_password` retrieves the secret (migrating legacy plaintext).
+3. **`connect`** validates host/protocol, branches on auth:
+   - **SSO** → service-mode + `nc` guards + `require_openconnect_sso` (≥ 9.0).
+   - **Duo passcode** → prompt at connect time (refused in service mode).
+   - Fail-closed server identity: `pin-sha256` pin, else `verify_gateway_cert`.
+4. **`run_openconnect`** builds the `openconnect` argv array (no `eval`) and invokes
+   `sudo openconnect …`:
+   - **Password mode:** `--passwd-on-stdin`; password (+ optional Duo answer) piped on stdin.
+   - **SSO mode:** `--external-browser=<resolved>`, **no** `--passwd-on-stdin`, **nothing**
+     piped to stdin (openconnect keeps the TTY), forced foreground.
+   - Background daemonizes (`--background`); foreground/service/SSO stay attached and
+     the PID is captured via `pgrep` after a short delay (openconnect only writes
+     `--pid-file` when daemonizing). `notify` + `run_hooks` fire on connect/disconnect.
+
+### 5.2 Browser-command resolution (SSO)
+`resolve_external_browser`: `VPN_UP_EXTERNAL_BROWSER` override → bundled
+`openconnect-external-browser` → platform default (`open` / `xdg-open`). OpenConnect
+opens the SSO URL and catches the returned token on its own localhost listener.
+
+### 5.3 `stop` / `status`
+Both scan `~/.config/vpn-up/pids/*.pid`. `status` reports details from the matching
+`.state` and prunes stale entries. `stop` does `sudo kill` (openconnect runs as root),
+waits, SIGKILL fallback, then cleans pid/state and fires the disconnected hook.
+
+### 5.4 Service mode
+`service install` writes a launchd plist (macOS) or systemd user unit (Linux) that runs
+`vpn-up start <profile>` with `VPN_UP_SERVICE=1` and supervises openconnect in the
+foreground (KeepAlive/Restart for auto-reconnect). `_service_preflight` refuses
+passcode and SSO profiles (interactive) and warns on missing passwordless sudo / stored
+password.
+
+## 6. Security model (summary)
+
+- **Config is executable shell** → sourced only after `assert_safe_to_source`
+  (owner == current user, not group/world-writable). Same check gates hooks.
+- **Secrets** live in OS keychain/keyring or an encrypted vault; the macOS path uses
+  `security -i` (stdin) to keep secrets out of `argv`; the vault uses `-pass env:` with
+  no decrypted temp files and fails closed on a wrong passphrase. Secrets are never `export`ed.
+- **Server identity** fails closed (pin or trust store). XPath built via `xpath_literal`
+  to prevent injection from profile names.
+- **Privilege** — only `openconnect`/`kill` run under `sudo`; the sudo password is never
+  stored. Optional scoped `sudoers.d` rule documented for non-interactive use.
+- Full model and reporting: [SECURITY.md](SECURITY.md).
+
+## 7. Quality & CI
+
+- **Tests:** `bats` suite under [tests/](tests/) (`cli`, `core`, `lifecycle`, `logging`,
+  `network`, `profiles`, `secrets`, `service`, `sso`, `ui_setup`), with stubs for
+  network, sudo, keychain, and service managers.
+- **CI** ([.github/workflows/ci.yml](.github/workflows/ci.yml)): shellcheck +
+  `bats tests/` on **macOS and Ubuntu** + gitleaks + CodeQL on every push/PR. `main` is
+  protected and PR-only.
+- **Release** ([.github/workflows/release-tap.yml](.github/workflows/release-tap.yml)):
+  publishing a GitHub release patches the Homebrew tap formula's `url` + `sha256`.
+
+## 8. Notable design decisions & trade-offs
+
+- **XML profiles via `xmlstarlet`** — human-editable and tag-alias tolerant; the cost is
+  a dependency and positional field loading (mitigated by append-only schema growth).
+- **Positional `mapfile` field loading** — fast and empty-field-safe (vs. `read -d`
+  which collapses blank fields); requires new fields to be appended last.
+- **One connection at a time** — per-profile state files make `status`/`stop`/`logs`
+  accurate without the complexity of concurrent tunnels.
+- **Wrapper, foreground PID capture via `pgrep`** — openconnect writes `--pid-file` only
+  when daemonizing, so foreground/service/SSO sessions self-record after a short delay.
+- **SSO forced foreground, no stdin pipe** — the single most important correctness
+  detail for browser auth; the TTY must stay attached.
+- **`PROGRAM_NAME` vs `DISPLAY_NAME`** — data-file/slug/Keychain namespace is decoupled
+  from user-facing naming, so the public command reads `vpn-up` without disturbing state paths.

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,164 @@
+# Product Requirements Document — VPN Up for OpenConnect
+
+**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-16 (v3.7.0)
+
+> This PRD describes *what* VPN Up is and *why*. For *how* it's built, see
+> [ARCHITECTURE.md](ARCHITECTURE.md). For the change history, see
+> [CHANGELOG.md](CHANGELOG.md).
+
+---
+
+## 1. Overview
+
+**VPN Up for OpenConnect** is a secure, scriptable command-line VPN manager built
+on top of [OpenConnect](https://www.infradead.org/openconnect/). It lets macOS and
+Linux users connect to Cisco AnyConnect, Palo Alto GlobalProtect, Pulse Secure,
+Juniper Network Connect, and ocserv gateways from the terminal — with named
+profiles, Duo 2FA, browser-based SSO, certificate pinning, secure secret storage,
+auto-reconnect, and shell completion.
+
+It is a *wrapper*, not a fork: OpenConnect does the tunnelling; VPN Up provides the
+profile management, credential hygiene, and lifecycle ergonomics that raw
+`openconnect` command lines lack.
+
+## 2. Problem statement
+
+Connecting to a corporate SSL VPN from the command line with raw OpenConnect means
+reassembling a long, error-prone invocation every time:
+
+```bash
+echo "$PASSWORD" | sudo openconnect --protocol=anyconnect --authgroup=Employees \
+  --user=me --servercert pin-sha256:… --passwd-on-stdin vpn.example.com
+```
+
+This has real problems:
+
+- **No profiles** — every gateway is a fresh command to remember.
+- **Credential leakage** — passwords end up in shell history, the process table, or
+  plaintext config files.
+- **2FA friction** — Duo prompts collide with AuthGroup selection and password input.
+- **No lifecycle** — no clean "is it up?", "stop it", "show me the log", or
+  "reconnect at login".
+- **The SSO trap** — modern gateways force a browser-based SAML/SSO login that the
+  password-on-stdin pattern simply cannot satisfy.
+
+The vendor GUI clients (Cisco AnyConnect Secure Mobility Client, GlobalProtect,
+etc.) solve some of this but are heavyweight, GUI-only, and fragile across OS
+upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
+
+## 3. Goals & non-goals
+
+### Goals
+- Make connecting to an OpenConnect-compatible VPN a **single command** (`vpn-up start "Work"`).
+- **Never** store or expose credentials in plaintext, argv, or child-process environments.
+- Support the **authentication methods real gateways use**: password, Duo 2FA
+  (push/phone/sms/passcode), and browser-based SAML/SSO.
+- Provide **lifecycle ergonomics**: status, stop, logs, restart, auto-reconnect at login.
+- Be **safe by default** (fail-closed server identity) and **auditable** (small, modular Bash).
+- Run identically on **macOS and Linux**.
+
+### Non-goals
+- **Windows support** — explicitly out of scope.
+- **A GUI** — terminal-first by design.
+- **Replacing OpenConnect** — VPN Up orchestrates it; it does not reimplement tunnelling.
+- **Multiple simultaneous tunnels** — one active connection at a time (per-profile
+  state files make bookkeeping accurate, not the tunnels concurrent). Under consideration.
+
+## 4. Target users & personas
+
+| Persona | Need |
+|---|---|
+| **Developer / DevOps engineer** | Script VPN startup before running tools or remote-support tasks; connect by name in one line. |
+| **Consultant** | Juggle many client VPN profiles on one machine without re-typing gateway details. |
+| **Remote worker** | Reliable connect-at-login with auto-reconnect; not dependent on a vendor GUI. |
+| **Security-conscious user** | Credentials in the OS keychain, certificate pinning, no plaintext, small auditable codebase. |
+
+## 5. User stories
+
+- *As a developer*, I run `vpn-up start "Work"` and I'm connected after a single Duo
+  push — no password typed, no command to remember.
+- *As a consultant*, I keep five client profiles and pick one from a menu (`vpn-up start`).
+- *As an SSO user*, I mark a profile `authMode=sso`, and `vpn-up start` opens my
+  browser for the Okta/Azure/Ping + Duo login, then the tunnel comes up.
+- *As a remote worker*, I run `vpn-up service install "Work"` so the VPN connects at
+  login and reconnects if it drops.
+- *As an operator*, I run `vpn-up status` / `vpn-up logs -f` / `vpn-up stop "Work"`
+  to see and control a specific connection.
+- *As a security reviewer*, I run `vpn-up doctor` to see the environment, dependency
+  versions, secret backend, and SSO availability at a glance.
+
+## 6. Functional requirements
+
+### 6.1 Connection
+- **FR-1** Connect by profile name (`start <profile>`) or via an interactive menu (`start`).
+- **FR-2** Support protocols `anyconnect`, `gp`, `pulse`, `nc`, with full AuthGroup/realm support.
+- **FR-3** Support Duo 2FA methods `push`, `phone`, `sms`, and one-time `passcode`
+  (prompted at connect time, never read from XML).
+- **FR-4** Support **browser-based SAML/SSO** (`authMode=sso`) via OpenConnect's
+  `--external-browser` (openconnect ≥ 9.0; `anyconnect`/`gp` only). No password is
+  piped; the flow runs foreground with the controlling TTY.
+- **FR-5** Background or foreground operation, configurable; SSO and service mode force foreground.
+
+### 6.2 Credentials & identity
+- **FR-6** Store secrets in the macOS Keychain, Linux Secret Service, or an
+  AES-256-CBC + PBKDF2 OpenSSL vault — never in plaintext files, argv, or child env.
+- **FR-7** Migrate any legacy plaintext `<password>` to the secrets backend and blank it in the XML.
+- **FR-8** Never store the sudo password; offer a documented scoped sudoers rule for passwordless use.
+- **FR-9** Fail closed on server identity: require a `pin-sha256` pin **or** system
+  trust-store validation; provide `pin` / `pin --save` helpers.
+
+### 6.3 Lifecycle & operations
+- **FR-10** `status` reports each running connection (profile, gateway, uptime) from per-profile state.
+- **FR-11** `stop [profile]` stops all or one connection (sudo kill + verify + SIGKILL fallback).
+- **FR-12** `logs [-f] [profile]` shows/follows the per-profile connection log.
+- **FR-13** `restart [profile]`, `list` / `list-names`.
+- **FR-14** Login service with auto-reconnect: `service install|uninstall|status`
+  (launchd on macOS, systemd user unit on Linux). SSO and passcode profiles are refused (interactive).
+- **FR-15** Lifecycle hooks: user scripts in `hooks/connected.d` / `hooks/disconnected.d`,
+  run with `VPN_EVENT`/`VPN_NAME`/`VPN_HOST` (never the password), skipped unless safely owned.
+
+### 6.4 Management & diagnostics
+- **FR-16** Guided `setup` wizard and `add-profile` / `remove-profile` (handle XML, secrets, pins, services).
+- **FR-17** `set-secret` / `delete-secret` for the secrets backend.
+- **FR-18** `doctor` reports OS, dependencies + openconnect version, secret backend, SSO availability, config.
+- **FR-19** Bash/zsh tab completion for commands and profile names.
+
+## 7. Non-functional requirements
+
+- **NFR-1 Security** — no plaintext secrets at rest or in transit to child processes;
+  config sourced only if user-owned and not group/world-writable; data files `600`,
+  dirs `700`; no `eval`. See [SECURITY.md](SECURITY.md).
+- **NFR-2 Portability** — macOS + Linux; Bash ≥ 4; GNU/BSD differences handled
+  (`stat`, `ps`, `sed`). No hard dependency beyond `openconnect`, `xmlstarlet`, and a secret backend.
+- **NFR-3 Isolation** — all user state under `~/.config/vpn-up` (override via
+  `VPN_UP_HOME`/`XDG_CONFIG_HOME`); reinstalling/cleaning the program directory never touches it.
+- **NFR-4 Quality** — shellcheck-clean; bats test suite on macOS + Ubuntu in CI; secret scanning (gitleaks) + CodeQL.
+- **NFR-5 Auditability** — small modular Bash, one concern per module; no opaque binaries.
+- **NFR-6 Reliability** — fail-closed identity; accurate per-profile PID/state bookkeeping; graceful stop with fallback.
+
+## 8. Success metrics
+
+- Time-to-connect for a configured profile: a single command + one 2FA approval.
+- Zero plaintext credentials discoverable on disk, in argv, or in `~/.bash_history`.
+- CI green (shellcheck + bats on both OSes + gitleaks + CodeQL) on every change.
+- Installable in one step via Homebrew tap; survives `brew upgrade`.
+
+## 9. Out of scope / explicit limitations
+
+- Windows; GUI; concurrent multi-tunnel.
+- SSO under a non-interactive login service (requires a desktop session).
+- SSO on the `nc` protocol (unsupported by OpenConnect).
+- On Linux, a root-spawned SSO browser may not reach the desktop session (mitigated by
+  the `VPN_UP_EXTERNAL_BROWSER` override).
+
+## 10. Roadmap (under consideration)
+
+- TOTP / RSA token support via OpenConnect's native `--token-mode`.
+- HTTP/SOCKS proxy passthrough as a profile field.
+- Multiple simultaneous tunnels (per-profile state already lays the groundwork).
+
+## 11. Release & distribution
+
+- Semantic Versioning; PR-only `main` with required CI. See [RELEASING.md](RELEASING.md).
+- Distributed via the `sorinipate/vpn-up` Homebrew tap; publishing a GitHub release
+  auto-updates the tap formula (`url` + `sha256`).

--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Background and design notes:
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow (PRs only, shellcheck + test suite must pass on macOS and Ubuntu).
 
+- 📐 Design docs: [PRD.md](PRD.md) (what & why) and [ARCHITECTURE.md](ARCHITECTURE.md) (how)
 - 🔐 Security issues: please report privately via [SECURITY.md](SECURITY.md), not public issues
 - 📄 Full release history: [CHANGELOG.md](CHANGELOG.md)
 - ⚖️ Licensed under the [MIT License](LICENSE) — © Sorin-Doru Ipate


### PR DESCRIPTION
## Summary

Adds two design documents and links them from the README:

- **[PRD.md](PRD.md)** — Product Requirements: overview, problem statement, goals/non-goals, personas, user stories, functional (FR-1…19) and non-functional (NFR-1…6) requirements, success metrics, out-of-scope/limitations, roadmap, and release/distribution.
- **[ARCHITECTURE.md](ARCHITECTURE.md)** — design principles, high-level diagram, per-module responsibility table, data/state layout + profile schema, key flows (start→connect→run_openconnect, SSO browser resolution, stop/status, service mode), security model summary, quality/CI, and notable design trade-offs.

Both reflect the codebase as of v3.7.0 (incl. SSO/external-browser). Docs-only.

## Test plan

- [ ] CI green (docs-only)