### PR TITLE
Add GitHub Pages documentation site (SEO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/badge/release-v3.7.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)
 
 ```text
@@ -419,6 +420,7 @@ Background and design notes:
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow (PRs only, shellcheck + test suite must pass on macOS and Ubuntu).
 
+- 📖 Documentation site: [sorinipate.github.io/vpn-up-for-openconnect](https://sorinipate.github.io/vpn-up-for-openconnect/)
 - 📐 Design docs: [PRD.md](PRD.md) (what & why) and [ARCHITECTURE.md](ARCHITECTURE.md) (how)
 - 🔐 Security issues: please report privately via [SECURITY.md](SECURITY.md), not public issues
 - 📄 Full release history: [CHANGELOG.md](CHANGELOG.md)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,40 @@
+# Jekyll config for the VPN Up documentation site (GitHub Pages).
+# Built by GitHub Pages from the /docs folder on main.
+
+title: VPN Up for OpenConnect
+description: >-
+  Secure, scriptable command-line VPN manager built on OpenConnect for Cisco
+  AnyConnect, Palo Alto GlobalProtect, Pulse Secure and Juniper VPNs on macOS
+  and Linux — with profiles, Duo 2FA, browser-based SSO, certificate pinning,
+  and auto-reconnect.
+
+# Project Pages site lives at https://<user>.github.io/<repo>/
+url: "https://sorinipate.github.io"
+baseurl: "/vpn-up-for-openconnect"
+
+author: Sorin-Doru Ipate
+lang: en_US
+repository: sorinipate/vpn-up-for-openconnect
+
+theme: minima
+plugins:
+  - jekyll-seo-tag      # per-page <title>, meta description, canonical, Open Graph
+  - jekyll-sitemap      # auto-generates /sitemap.xml
+
+# Top navigation (minima renders these in page order)
+header_pages:
+  - installation.md
+  - usage.md
+  - sso-duo.md
+  - protocols.md
+  - troubleshooting.md
+
+minima:
+  skin: dark
+  social_links:
+    - { platform: github, user_url: "https://github.com/sorinipate/vpn-up-for-openconnect" }
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+---
+layout: home
+title: VPN Up for OpenConnect — Secure CLI VPN Manager for macOS & Linux
+description: >-
+  VPN Up is a secure, scriptable command-line VPN manager built on OpenConnect.
+  Connect to Cisco AnyConnect, GlobalProtect, Pulse Secure and Juniper gateways
+  from the terminal on macOS and Linux, with Duo 2FA and browser-based SSO.
+permalink: /
+---
+
+# VPN Up for OpenConnect
+
+**VPN Up** is a secure, scriptable command-line VPN manager built on
+[OpenConnect](https://www.infradead.org/openconnect/). It connects macOS and
+Linux machines to **Cisco AnyConnect**, Palo Alto **GlobalProtect**, **Pulse
+Secure**, **Juniper Network Connect**, and **ocserv** gateways straight from the
+terminal — with named profiles, **Duo 2FA**, **browser-based SSO**, certificate
+pinning, secure secret storage, auto-reconnect, and shell completion.
+
+It's built for developers, consultants, DevOps engineers, and remote workers who
+would rather drive their VPN from the command line than a vendor GUI.
+
+```console
+$ vpn-up start "Frankfurt VPN"
+Starting the Frankfurt VPN on frankfurt.example.com using Cisco AnyConnect ...
+Connecting with Two-Factor Authentication (2FA) from Duo (PUSH) ...
+Connected to Frankfurt VPN
+```
+
+## Install in one step
+
+```bash
+brew tap sorinipate/vpn-up
+brew install vpn-up
+```
+
+See the [installation guide]({{ '/installation/' | relative_url }}) for manual setup on macOS and Linux.
+
+## Why VPN Up?
+
+- Connect to Cisco AnyConnect-compatible VPNs **without the vendor GUI client**
+- Manage **multiple VPN profiles** and connect by name (`vpn-up start "Work"`)
+- **Duo 2FA** from the command line — push, phone, SMS, or one-time passcode
+- **Browser-based SSO** (Okta, Azure AD, Ping Identity) for gateways that force an external browser login
+- Secrets in the macOS **Keychain**, Linux **Secret Service**, or an encrypted vault — never plaintext
+- **Auto-reconnect at login** via launchd (macOS) or systemd (Linux)
+- Scriptable: drop VPN startup into your dev, automation, and remote-support workflows
+
+## Documentation
+
+- [Installation]({{ '/installation/' | relative_url }}) — Homebrew and manual setup on macOS & Linux
+- [Usage]({{ '/usage/' | relative_url }}) — commands, profiles, status/stop/logs, login service, hooks
+- [SSO & Duo 2FA]({{ '/sso-duo/' | relative_url }}) — browser-based SAML/SSO login with Okta, Azure AD, Ping
+- [Protocols]({{ '/protocols/' | relative_url }}) — AnyConnect, GlobalProtect, Pulse Secure, Juniper
+- [Troubleshooting]({{ '/troubleshooting/' | relative_url }}) — common connection problems and fixes
+
+## Open source
+
+VPN Up is MIT-licensed and developed on
+[GitHub](https://github.com/sorinipate/vpn-up-for-openconnect). Issues and pull
+requests are welcome.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: Installation
+description: >-
+  Install VPN Up, an OpenConnect VPN command-line client, on macOS and Linux via
+  Homebrew or manually. Dependencies: openconnect, xmlstarlet, modern Bash.
+permalink: /installation/
+---
+
+# Installing VPN Up on macOS and Linux
+
+VPN Up is a wrapper around [OpenConnect](https://www.infradead.org/openconnect/),
+so it needs `openconnect`, `xmlstarlet`, and Bash ≥ 4. Your data always lives in
+`~/.config/vpn-up`, untouched by upgrades or reinstalls.
+
+## Homebrew (macOS / Linux — recommended)
+
+```bash
+brew tap sorinipate/vpn-up
+brew install vpn-up
+```
+
+This installs the `vpn-up` command with all dependencies and bash completion, and
+upgrades cleanly with `brew upgrade vpn-up`.
+
+## Manual — macOS (Apple Silicon / Intel)
+
+macOS ships with Bash 3.2, so install modern Bash and the dependencies:
+
+```bash
+brew install bash openconnect xmlstarlet
+echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zprofile
+exec $SHELL -l
+```
+
+Then clone and run:
+
+```bash
+git clone https://github.com/sorinipate/vpn-up-for-openconnect.git
+cd vpn-up-for-openconnect
+chmod +x vpn-up.command
+./vpn-up.command setup
+```
+
+## Manual — Linux
+
+```bash
+# Debian / Ubuntu
+sudo apt install bash openconnect xmlstarlet openssl
+
+# RHEL / CentOS
+sudo yum install bash openconnect xmlstarlet openssl
+
+# Fedora
+sudo dnf install bash openconnect xmlstarlet openssl
+```
+
+Optional (recommended): `secret-tool` for Secret Service keyring storage. For
+[browser-based SSO]({{ '/sso-duo/' | relative_url }}), you need **OpenConnect ≥ 9.0**.
+
+## Verify your environment
+
+```bash
+vpn-up doctor
+```
+
+`doctor` reports your OS, dependencies and OpenConnect version, the active secret
+backend, and whether SSO (external browser) is supported.
+
+Next: [usage and commands]({{ '/usage/' | relative_url }}).

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: Supported protocols
+description: >-
+  Connect to Cisco AnyConnect, Palo Alto GlobalProtect, Pulse Secure and Juniper
+  Network Connect VPNs from the command line via OpenConnect with VPN Up.
+permalink: /protocols/
+---
+
+# Supported VPN protocols
+
+VPN Up speaks every SSL-VPN protocol that [OpenConnect](https://www.infradead.org/openconnect/)
+supports. Set `<protocol>` on a profile (or pick it in `vpn-up add-profile`).
+
+| Protocol value | Gateway | Notes |
+|---|---|---|
+| `anyconnect` | **Cisco AnyConnect** (and ocserv) | Default. Full AuthGroup/realm and [browser SSO]({{ '/sso-duo/' | relative_url }}) support. |
+| `gp` | **Palo Alto GlobalProtect** | Portal/gateway login; browser SSO supported. |
+| `pulse` | **Pulse Connect Secure** | Pulse/Ivanti SSL VPN. |
+| `nc` | **Juniper Network Connect** | Legacy Juniper; no SSO support. |
+
+## Cisco AnyConnect from the command line
+
+A command-line alternative to the Cisco AnyConnect Secure Mobility Client for any
+AnyConnect-compatible gateway:
+
+```bash
+vpn-up start "Work VPN"   # protocol: anyconnect
+```
+
+Supports AuthGroup/realm selection, Duo 2FA, certificate pinning, and
+[browser-based SSO]({{ '/sso-duo/' | relative_url }}) for Okta/Azure AD/Ping gateways.
+
+## GlobalProtect, Pulse Secure, and Juniper
+
+Set the matching protocol value in the profile:
+
+```xml
+<VPN>
+  <name>GP VPN</name>
+  <protocol>gp</protocol>          <!-- or: pulse, nc -->
+  <host>gw.example.com</host>
+  <user>you</user>
+</VPN>
+```
+
+GlobalProtect supports browser SSO; Pulse and Juniper use password / Duo 2FA flows.
+
+## Not sure what your gateway speaks?
+
+If the vendor client is "Cisco AnyConnect," use `anyconnect`. For Palo Alto
+GlobalProtect use `gp`. When in doubt, try `anyconnect` first — many gateways are
+AnyConnect-compatible. See [troubleshooting]({{ '/troubleshooting/' | relative_url }})
+if a connection fails.

--- a/docs/sso-duo.md
+++ b/docs/sso-duo.md
@@ -1,0 +1,85 @@
+---
+layout: page
+title: SSO & Duo 2FA
+description: >-
+  Browser-based SAML/SSO login (Okta, Azure AD, Ping Identity) with an embedded
+  Duo iframe, plus Duo push/phone/sms/passcode — from the OpenConnect command line.
+permalink: /sso-duo/
+---
+
+# Browser-based SSO and Duo 2FA with OpenConnect
+
+Modern corporate gateways increasingly force a **browser-based SAML/SSO login** —
+an Okta, Azure AD, or Ping Identity page, often wrapping an embedded **Duo**
+iframe — instead of accepting a username and password on the command line. VPN Up
+handles both classic Duo 2FA and the browser-based "SSO trap."
+
+## Duo 2FA (push, phone, SMS, passcode)
+
+Set the Duo method on a profile and VPN Up handles the prompt order so Duo and
+AuthGroup selection don't collide:
+
+- `push` — approve on your phone (Duo Mobile)
+- `phone` — callback to your registered phone
+- `sms` — texted passcodes
+- `passcode` — one-time code, prompted at connect time (never read from config)
+- *empty* — let the gateway auto-push
+
+```bash
+vpn-up start "Work VPN"   # connect; approve the Duo push when prompted
+```
+
+## Browser-based SSO (Okta, Azure AD, Ping Identity)
+
+For gateways that require an external browser login, mark the profile with
+`authMode=sso` — either answer **yes** to the SSO prompt in `vpn-up add-profile`,
+or set it in the profile XML:
+
+```xml
+<VPN>
+  <name>Work SSO</name>
+  <protocol>anyconnect</protocol>   <!-- anyconnect or gp; not nc -->
+  <host>vpn.example.com</host>
+  <authMode>sso</authMode>
+</VPN>
+```
+
+Then connect normally:
+
+```bash
+vpn-up start "Work SSO"
+```
+
+VPN Up runs OpenConnect with `--external-browser`: it opens your browser to the
+identity provider, you complete the login (including Duo) there, and the tunnel
+comes up afterward. **No password is stored or piped** for SSO profiles.
+
+### Requirements and behavior
+
+- **OpenConnect ≥ 9.0** (when `--external-browser` landed). `vpn-up doctor` reports
+  your version and whether SSO is available.
+- Supported for the **`anyconnect`** and **`gp`** protocols (not `nc`).
+- Runs in the **foreground**; an SSO profile **cannot run as a login service**
+  because it needs an interactive desktop session.
+
+### Linux + sudo: getting the browser to open
+
+OpenConnect runs as root via `sudo`, so a root-spawned browser may not reach your
+desktop session on Linux. If the browser doesn't appear, point VPN Up at a
+session-aware opener:
+
+```bash
+# ~/bin/vpn-up-browser  (chmod +x)
+#!/bin/sh
+exec sudo -u "$SUDO_USER" xdg-open "$@"
+```
+
+```bash
+export VPN_UP_EXTERNAL_BROWSER="$HOME/bin/vpn-up-browser"
+```
+
+`VPN_UP_EXTERNAL_BROWSER` overrides the opener (default: `open` on macOS,
+`xdg-open` on Linux, or the bundled `openconnect-external-browser` helper).
+
+See also: [usage]({{ '/usage/' | relative_url }}) and
+[supported protocols]({{ '/protocols/' | relative_url }}).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,77 @@
+---
+layout: page
+title: Troubleshooting
+description: >-
+  Fixes for common OpenConnect VPN problems with VPN Up: Login failed, Unexpected
+  404, sudo prompts, SSO browser not opening on Linux, and openconnect version.
+permalink: /troubleshooting/
+---
+
+# Troubleshooting
+
+Start with `vpn-up doctor` — it reports your OS, dependency and OpenConnect
+versions, the active secret backend, and SSO availability.
+
+## "Login failed"
+
+Usually a stale stored password. Reset it and reconnect:
+
+```bash
+vpn-up delete-secret "Work VPN" password
+vpn-up start "Work VPN"
+```
+
+For Duo, make sure the profile's method matches what your account expects
+(`push`/`phone`/`sms`/`passcode`). See [SSO & Duo 2FA]({{ '/sso-duo/' | relative_url }}).
+
+## "Unexpected 404 result from server"
+
+Some Cisco AnyConnect gateways emit this banner on connect. It is **benign** if
+the connection then proceeds and the tunnel comes up.
+
+## It keeps asking for my sudo password
+
+`openconnect` needs root, so VPN Up runs it under `sudo`. For non-interactive use
+(and for the login service), add a sudoers rule scoped to the one binary:
+
+```bash
+# macOS (Homebrew):
+echo "$USER ALL=(root) NOPASSWD: /opt/homebrew/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
+# Linux:
+echo "$USER ALL=(root) NOPASSWD: /usr/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
+sudo chmod 440 /etc/sudoers.d/vpn-up
+```
+
+The sudo password is **never** stored. Verify the binary path with
+`command -v openconnect`.
+
+## SSO browser doesn't open (Linux)
+
+Because `openconnect` runs as root, a root-spawned browser may not reach your
+desktop session. Point VPN Up at a session-aware opener via
+`VPN_UP_EXTERNAL_BROWSER` — see the
+[SSO guide]({{ '/sso-duo/' | relative_url }}#linux--sudo-getting-the-browser-to-open).
+
+## "SSO needs openconnect >= 9.0"
+
+Browser-based SSO uses OpenConnect's `--external-browser`, added in 9.0. Upgrade:
+
+```bash
+brew upgrade openconnect          # macOS / Linuxbrew
+sudo apt install --only-upgrade openconnect   # Debian/Ubuntu
+```
+
+Check with `openconnect --version` or `vpn-up doctor`.
+
+## Can't run an SSO profile as a login service
+
+Correct — SSO needs an interactive browser, so `service install` refuses SSO (and
+Duo `passcode`) profiles. Use a non-interactive method (`push`/`phone`/`sms`) for
+the [login service]({{ '/usage/' | relative_url }}#login-service-with-auto-reconnect).
+
+## Still stuck?
+
+Open an issue on
+[GitHub](https://github.com/sorinipate/vpn-up-for-openconnect/issues) with the
+output of `vpn-up doctor` and the last lines of `vpn-up logs` (redact anything
+sensitive).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,83 @@
+---
+layout: page
+title: Usage
+description: >-
+  Connect to a VPN from the command line with VPN Up: named profiles, status,
+  stop, logs, certificate pinning, login service with auto-reconnect, and hooks.
+permalink: /usage/
+---
+
+# Using VPN Up from the command line
+
+After [installing]({{ '/installation/' | relative_url }}), run the one-time setup
+and create your first profile:
+
+```bash
+vpn-up setup          # one-time configuration wizard
+vpn-up add-profile    # guided profile creation (+ password, + certificate pin)
+vpn-up start          # connect (interactive menu)
+```
+
+> Manual installs use `./vpn-up.command` instead of `vpn-up`.
+
+## Core commands
+
+```bash
+vpn-up start                       # interactive profile menu
+vpn-up start "Frankfurt VPN"       # connect directly (scriptable)
+vpn-up list                        # list configured profiles (name, protocol, host, 2FA, auth)
+vpn-up add-profile                 # guided profile creation
+vpn-up remove-profile "Old VPN"    # remove profile + secret + logs + service
+vpn-up status                      # profile, gateway, uptime
+vpn-up logs -f                     # follow the connection log
+vpn-up stop                        # stop the VPN (or: stop "Frankfurt VPN")
+vpn-up doctor                      # diagnose environment & secret backend
+```
+
+Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so
+`status`, `stop`, and `logs` are profile-aware.
+
+## Secure secret storage
+
+Passwords are stored in the macOS **Keychain**, the Linux **Secret Service**, or
+an AES-256-CBC + PBKDF2 OpenSSL vault — never in plaintext files, never on the
+command line, never exported to child processes.
+
+```bash
+vpn-up set-secret "Frankfurt VPN" password
+vpn-up delete-secret "Frankfurt VPN" password
+```
+
+## Login service with auto-reconnect
+
+Connect at login and reconnect automatically if the tunnel drops — launchd on
+macOS, a systemd user unit on Linux:
+
+```bash
+vpn-up service install "Frankfurt VPN"
+vpn-up service status
+vpn-up service uninstall "Frankfurt VPN"
+```
+
+Requirements: a passwordless sudoers rule for `openconnect`, a stored password,
+and a non-interactive 2FA method (push/phone/sms — not passcode, and not SSO).
+
+## Certificate pinning
+
+```bash
+vpn-up pin vpn.example.com          # print the pin-sha256 value
+vpn-up pin --save "Frankfurt VPN"   # write it into the profile
+```
+
+If no pin is configured, the gateway certificate must validate against the system
+trust store, or VPN Up refuses to connect (fail closed).
+
+## Lifecycle hooks
+
+Drop executable scripts in `~/.config/vpn-up/hooks/connected.d/` or
+`disconnected.d/` to run your own actions on tunnel up/down (mount shares, switch
+proxies). Hooks receive `VPN_EVENT`, `VPN_NAME`, and `VPN_HOST` — never the
+password — and are skipped unless owned by you and not group/world-writable.
+
+See also: [SSO & Duo 2FA]({{ '/sso-duo/' | relative_url }}) and
+[supported protocols]({{ '/protocols/' | relative_url }}).


### PR DESCRIPTION
## Summary

Adds a `/docs` Jekyll site to serve as the SEO-focused documentation surface (stronger than a wiki — indexable, controllable meta, sitemap).

- **Theme/plugins:** `minima` (built-in, no remote-theme build risk) + `jekyll-seo-tag` (per-page `<title>`, meta description, canonical, Open Graph) + `jekyll-sitemap` (auto `/sitemap.xml`).
- **Keyword-targeted pages:** Home, Installation, Usage, **SSO & Duo 2FA**, **Protocols** (AnyConnect/GlobalProtect/Pulse/Juniper), Troubleshooting — each with its own SEO title + description.
- **README:** Docs badge + documentation-site link.

After merge I'll enable Pages from `main` `/docs` and set the repo homepage. Site URL: https://sorinipate.github.io/vpn-up-for-openconnect/

## Test plan

- [ ] CI green (docs-only; shellcheck/bats unaffected)
- [ ] Pages builds and serves after enabling