### PR TITLE
docs: add long-tail SEO guide pages

### DIFF
--- a/docs/anyconnect-cli-alternative.md
+++ b/docs/anyconnect-cli-alternative.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: A Cisco AnyConnect command-line alternative for macOS & Linux
+description: >-
+  Use VPN Up and OpenConnect as a terminal alternative to the Cisco AnyConnect
+  Secure Mobility Client on macOS and Linux — profiles, Duo 2FA, and SSO included.
+permalink: /anyconnect-cli-alternative/
+---
+
+# A Cisco AnyConnect command-line alternative
+
+If you connect to a Cisco AnyConnect VPN but would rather not run the official
+**AnyConnect Secure Mobility Client** GUI, VPN Up gives you a terminal-first
+alternative built on [OpenConnect](https://www.infradead.org/openconnect/), which
+speaks the AnyConnect protocol (and works with ocserv too).
+
+> VPN Up is **not** the official Cisco client and is not affiliated with Cisco. It
+> is a wrapper around OpenConnect for gateways that support an AnyConnect-compatible
+> protocol.
+
+## What you get instead of the GUI
+
+| AnyConnect GUI feature | With VPN Up |
+|---|---|
+| Pick a connection profile | Named profiles — `vpn-up start "Work"` or an interactive menu |
+| Group / realm selection | `<authGroup>` per profile (passed as `--authgroup`) |
+| Duo / MFA prompt | `push` / `phone` / `sms` / `passcode`, or [browser SSO]({{ '/sso-duo/' | relative_url }}) |
+| Saved password | Stored in the macOS Keychain / Linux keyring — never plaintext |
+| Server certificate trust | `pin-sha256` pinning or system trust-store validation (fail closed) |
+| Connect / disconnect / status | `start` / `stop` / `status` / `logs -f`, all profile-aware |
+
+## Set it up
+
+```bash
+brew tap sorinipate/vpn-up
+brew install vpn-up
+vpn-up add-profile        # protocol: anyconnect; enter host, group, user
+vpn-up start "Work VPN"   # connect; approve Duo when prompted
+```
+
+See the [installation guide]({{ '/installation/' | relative_url }}) for manual
+setup, and [SSO & Duo 2FA]({{ '/sso-duo/' | relative_url }}) if your gateway forces
+a browser-based Okta/Azure AD/Ping login.
+
+## When it works (and when it doesn't)
+
+VPN Up works wherever OpenConnect can connect to your gateway — the vast majority
+of AnyConnect SSL-VPN deployments and ocserv. It does **not** implement
+proprietary posture/HostScan agents some enterprises require; if your gateway
+mandates the Cisco endpoint-posture client, you may still need the official app.
+Otherwise, the command line is all you need.
+
+Related: [supported protocols]({{ '/protocols/' | relative_url }}) ·
+[VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}).

--- a/docs/globalprotect-cli.md
+++ b/docs/globalprotect-cli.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: Connect to GlobalProtect from the command line (OpenConnect)
+description: >-
+  Connect to a Palo Alto GlobalProtect VPN from the terminal on macOS and Linux
+  using OpenConnect and VPN Up — portal/gateway host, SSO, and Duo supported.
+permalink: /globalprotect-cli/
+---
+
+# Connect to GlobalProtect from the command line
+
+VPN Up connects to **Palo Alto GlobalProtect** gateways through OpenConnect's `gp`
+protocol — a terminal alternative to the GlobalProtect app on macOS and Linux.
+
+## Create a GlobalProtect profile
+
+Use the wizard (`vpn-up add-profile`, choose protocol `gp`) or write the profile
+XML directly:
+
+```xml
+<VPN>
+  <name>GP VPN</name>
+  <protocol>gp</protocol>
+  <host>gateway.example.com</host>   <!-- portal or gateway host -->
+  <user>you</user>
+  <authMode>password</authMode>      <!-- or: sso -->
+</VPN>
+```
+
+Then connect:
+
+```bash
+vpn-up start "GP VPN"
+```
+
+## Portal vs. gateway host
+
+GlobalProtect deployments expose a **portal** and one or more **gateways**.
+OpenConnect can usually connect using either hostname; if a portal returns a
+gateway list, point the profile at the specific gateway you want. If your
+organization publishes a dedicated gateway hostname, prefer that.
+
+## SSO and Duo
+
+GlobalProtect frequently uses a **browser-based SAML/SSO login** (Okta, Azure AD,
+Ping) with Duo. Set `authMode=sso` on the profile and VPN Up opens your browser
+for the login — see [SSO & Duo 2FA]({{ '/sso-duo/' | relative_url }}) (requires
+OpenConnect ≥ 9.0). For non-SSO gateways, use a Duo method (`push`/`phone`/`sms`).
+
+## Troubleshooting
+
+If the connection is rejected, double-check the host (portal vs. gateway) and your
+group/realm, and run `vpn-up doctor` to confirm your OpenConnect version. More
+fixes on the [troubleshooting page]({{ '/troubleshooting/' | relative_url }}).
+
+Related: [supported protocols]({{ '/protocols/' | relative_url }}) ·
+[Cisco AnyConnect CLI alternative]({{ '/anyconnect-cli-alternative/' | relative_url }}).

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,13 @@ See the [installation guide]({{ '/installation/' | relative_url }}) for manual s
 - [Protocols]({{ '/protocols/' | relative_url }}) — AnyConnect, GlobalProtect, Pulse Secure, Juniper
 - [Troubleshooting]({{ '/troubleshooting/' | relative_url }}) — common connection problems and fixes
 
+## Guides
+
+- [Cisco AnyConnect command-line alternative]({{ '/anyconnect-cli-alternative/' | relative_url }}) — connect to AnyConnect VPNs without the GUI client
+- [Connect to GlobalProtect from the command line]({{ '/globalprotect-cli/' | relative_url }}) — Palo Alto GlobalProtect via OpenConnect
+- [Auto-connect a VPN at login]({{ '/vpn-at-login/' | relative_url }}) — launchd (macOS) & systemd (Linux) with auto-reconnect
+- [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}) — what the wrapper adds, and when to use each
+
 ## Open source
 
 VPN Up is MIT-licensed and developed on

--- a/docs/vpn-at-login.md
+++ b/docs/vpn-at-login.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: Auto-connect a VPN at login (launchd & systemd)
+description: >-
+  Run an OpenConnect VPN as a login service with auto-reconnect on macOS (launchd)
+  and Linux (systemd) using VPN Up — setup, requirements, and the sudoers rule.
+permalink: /vpn-at-login/
+---
+
+# Auto-connect a VPN at login, with auto-reconnect
+
+VPN Up can run a profile as a **login service** that connects when you log in and
+**reconnects automatically** if the tunnel drops — a launchd user agent on macOS
+and a systemd user unit on Linux.
+
+```bash
+vpn-up service install "Work VPN"     # connect at login + auto-reconnect
+vpn-up service status                 # list installed services
+vpn-up service uninstall "Work VPN"   # remove it
+```
+
+The service manager supervises `openconnect` in the foreground and relaunches it
+on drop (30-second throttle).
+
+## Requirements
+
+Because there's no terminal to type into at login, a service profile needs:
+
+1. **A passwordless sudoers rule** scoped to the `openconnect` binary:
+
+   ```bash
+   # macOS (Homebrew):
+   echo "$USER ALL=(root) NOPASSWD: /opt/homebrew/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
+   # Linux:
+   echo "$USER ALL=(root) NOPASSWD: /usr/sbin/openconnect" | sudo tee /etc/sudoers.d/vpn-up
+   sudo chmod 440 /etc/sudoers.d/vpn-up
+   ```
+
+2. **A stored password** — `vpn-up set-secret "Work VPN" password`.
+3. **A non-interactive 2FA method** — `push`, `phone`, or `sms`. Duo `passcode` and
+   [browser SSO]({{ '/sso-duo/' | relative_url }}) profiles are **refused**, since
+   both need interaction.
+
+`vpn-up service install` runs these preflight checks and warns you if anything is missing.
+
+## Linux: start before you log in (optional)
+
+By default a systemd *user* unit starts at your graphical/login session. To have it
+start at boot (before interactive login), enable lingering for your user:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+## Inspecting the service
+
+```bash
+# macOS — service log:
+tail -f ~/.config/vpn-up/logs/service.*.log
+# Linux — unit status & logs:
+systemctl --user status 'vpn-up-*'
+journalctl --user -u 'vpn-up-*' -f
+```
+
+See [usage]({{ '/usage/' | relative_url }}) for the full command set and
+[troubleshooting]({{ '/troubleshooting/' | relative_url }}) for sudo/connection issues.

--- a/docs/vs-openconnect.md
+++ b/docs/vs-openconnect.md
@@ -1,0 +1,59 @@
+---
+layout: page
+title: VPN Up vs. raw OpenConnect
+description: >-
+  How VPN Up compares to running openconnect directly — profiles, secure secrets,
+  Duo 2FA, SSO, certificate pinning, and auto-reconnect, versus long ad-hoc commands.
+permalink: /vs-openconnect/
+---
+
+# VPN Up vs. raw OpenConnect
+
+VPN Up is **not** a replacement for [OpenConnect](https://www.infradead.org/openconnect/)
+— it's a thin, secure wrapper around it. OpenConnect does the tunnelling; VPN Up
+adds the profile management and credential hygiene that raw command lines lack.
+
+## The raw way
+
+```bash
+echo "$PASSWORD" | sudo openconnect --protocol=anyconnect --authgroup=Employees \
+  --user=me --servercert pin-sha256:… --passwd-on-stdin vpn.example.com
+```
+
+Every gateway is a long command to remember, the password lands in your shell
+history and the process table, and there's no "is it up?", "stop it", or
+"reconnect at login."
+
+## The VPN Up way
+
+```bash
+vpn-up start "Work VPN"
+```
+
+## Side by side
+
+| Capability | Raw `openconnect` | VPN Up |
+|---|:---:|:---:|
+| Multiple named profiles | manual | ✅ |
+| Secrets in Keychain / keyring / encrypted vault | — | ✅ |
+| Password kept out of argv & shell history | manual | ✅ |
+| Duo 2FA prompt ordering (push/phone/sms/passcode) | manual | ✅ |
+| Browser-based SSO (`--external-browser`) wiring | manual | ✅ |
+| Certificate-pinning helper (`pin` / `pin --save`) | manual | ✅ |
+| Profile-aware `status` / `logs -f` / `stop` | — | ✅ |
+| Auto-reconnect login service (launchd/systemd) | manual | ✅ |
+| Connect/disconnect hooks & desktop notifications | — | ✅ |
+| Shell completion | — | ✅ |
+
+## When to use which
+
+- **Use raw `openconnect`** for a one-off connection, scripting around a single
+  fixed gateway, or debugging the tunnel itself.
+- **Use VPN Up** when you connect regularly, juggle multiple gateways, want
+  credentials stored safely, need Duo/SSO handled cleanly, or want connect-at-login.
+
+Under the hood it's still OpenConnect — so anything your gateway needs that
+OpenConnect supports keeps working.
+
+Get started: [installation]({{ '/installation/' | relative_url }}) ·
+[usage]({{ '/usage/' | relative_url }}).


### PR DESCRIPTION
## Summary

Four distinct, high-intent guide pages added to the docs site, cross-linked from the home page (internal-link equity) and auto-included in the sitemap:

- `/anyconnect-cli-alternative/` — Cisco AnyConnect command-line alternative
- `/globalprotect-cli/` — Connect to GlobalProtect from the command line
- `/vpn-at-login/` — Auto-connect a VPN at login (launchd & systemd)
- `/vs-openconnect/` — VPN Up vs. raw OpenConnect

Each has its own SEO title/description and unique content (not thin rewrites). Top nav stays lean; these are linked via the home page "Guides" section + related-page links.

## Test plan

- [ ] CI green (docs-only)
- [ ] Pages rebuilds; new URLs serve and appear in /sitemap.xml