### PR TITLE
docs: add Related articles to the Pages home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,14 @@ See the [installation guide]({{ '/installation/' | relative_url }}) for manual s
 - [Auto-connect a VPN at login]({{ '/vpn-at-login/' | relative_url }}) — launchd (macOS) & systemd (Linux) with auto-reconnect
 - [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}) — what the wrapper adds, and when to use each
 
+## Related articles
+
+Background and design notes:
+
+- [A Safer OpenConnect Workflow for Cisco AnyConnect VPNs on macOS and Linux](https://architegrity.com/blog/safer-openconnect-workflow-cisco-anyconnect-macos-linux) — Architegrity
+- [A Safer OpenConnect Workflow for Cisco AnyConnect VPNs on macOS and Linux](https://dev.to/sorinipate/a-safer-openconnect-workflow-for-cisco-anyconnect-vpns-on-macos-and-linux-5g7o) — Dev.to
+- [A Safer OpenConnect Workflow for Cisco AnyConnect VPNs on macOS and Linux](https://medium.com/@sorin.ipate/a-safer-openconnect-workflow-for-cisco-anyconnect-vpns-on-macos-and-linux-50062d66b082) — Medium
+
 ## Open source
 
 VPN Up is MIT-licensed and developed on


### PR DESCRIPTION
Adds a Related articles section (Architegrity, Dev.to, Medium cross-posts) to the docs site home page, mirroring the README. Reciprocal links support SEO. Docs-only.