### PR TITLE
docs/README: add understated Buy Me a Coffee link

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,5 +425,6 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the wor
 - 🔐 Security issues: please report privately via [SECURITY.md](SECURITY.md), not public issues
 - 📄 Full release history: [CHANGELOG.md](CHANGELOG.md)
 - ⚖️ Licensed under the [MIT License](LICENSE) — © Sorin-Doru Ipate
+- ☕ If it saves you time, you can [buy me a coffee](https://buymeacoffee.com/sorinipate)
 
 Thanks to all contributors and users who helped test and refine this project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,4 +73,5 @@ Background and design notes:
 
 VPN Up is MIT-licensed and developed on
 [GitHub](https://github.com/sorinipate/vpn-up-for-openconnect). Issues and pull
-requests are welcome.
+requests are welcome — and if it saves you time, you can
+[buy me a coffee ☕](https://buymeacoffee.com/sorinipate).


### PR DESCRIPTION
Adds a single, low-key support link in the docs home 'Open source' section and the README 'Contributing & License' list — reaching docs-site visitors who never see the repo's Sponsor button. Docs-only.