### PR TITLE
Revert Buy Me a Coffee handle to sorinipate

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # Shows a "Sponsor" button on the repository.
 # https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
-buy_me_a_coffee: vpnupforopenconnect
+buy_me_a_coffee: sorinipate

--- a/README.md
+++ b/README.md
@@ -425,6 +425,6 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the wor
 - 🔐 Security issues: please report privately via [SECURITY.md](SECURITY.md), not public issues
 - 📄 Full release history: [CHANGELOG.md](CHANGELOG.md)
 - ⚖️ Licensed under the [MIT License](LICENSE) — © Sorin-Doru Ipate
-- ☕ If it saves you time, you can [buy me a coffee](https://buymeacoffee.com/vpnupforopenconnect)
+- ☕ If it saves you time, you can [buy me a coffee](https://buymeacoffee.com/sorinipate)
 
 Thanks to all contributors and users who helped test and refine this project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,4 +74,4 @@ Background and design notes:
 VPN Up is MIT-licensed and developed on
 [GitHub](https://github.com/sorinipate/vpn-up-for-openconnect). Issues and pull
 requests are welcome — and if it saves you time, you can
-[buy me a coffee ☕](https://buymeacoffee.com/vpnupforopenconnect).
+[buy me a coffee ☕](https://buymeacoffee.com/sorinipate).


### PR DESCRIPTION
Switches the Sponsor button + README/docs support links back to https://buymeacoffee.com/sorinipate (more personal). Config/docs-only.