### PR TITLE
Add TOTP authenticator-app 2FA (tokenMode=totp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [Unreleased]
+
+### Added
+- **TOTP authenticator-app 2FA** (`<tokenMode>totp</tokenMode>`). For gateways
+  that prompt for a time-based code (Google Authenticator / Authy / hardware
+  TOTP), store the base32 seed once (`vpn-up set-secret '<profile>' token_secret`,
+  or via the `add-profile` wizard) and `vpn-up` generates the current code with
+  `oathtool` at connect time and feeds it as the 2FA answer. The **seed never
+  reaches openconnect's argv or disk** — only the short-lived code transits on
+  stdin (we deliberately avoid `--token-secret`, which would expose it). Because
+  it needs no interaction, a TOTP profile **can run as a login service with
+  auto-reconnect** (unlike Duo-passcode and SSO). New `oathtool` dependency
+  (TOTP only); surfaced by `doctor`; shown in `vpn-up list`.
+
+---
+
 ## [v3.7.0] — 2026-06-16
 ### Browser-based SSO Login Update
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ VPN Up is useful if you:
 - **Four SSL VPN protocols** via [OpenConnect](https://www.infradead.org/openconnect/): Cisco **AnyConnect** (and ocserv), Juniper **Network Connect**, Palo Alto **GlobalProtect**, and **Pulse Secure**
 - **Multiple VPN profiles** — pick from an interactive menu or connect by name with zero prompts (`vpn-up start "Work VPN"`), with full **AuthGroup/realm** support
 - **Duo 2FA** — `push`, `phone`, `sms`, or one-time passcodes prompted at connect time; empty method lets the gateway auto-push
+- **TOTP authenticator-app 2FA** — store the seed once and `vpn-up` generates the code at connect time (via `oathtool`); fully non-interactive, so it works as an auto-reconnecting login service
 - **SSO / external-browser login** — for gateways that force a browser-based SAML/SSO flow (Okta, Azure AD, Ping Identity, often with an embedded Duo iframe), via OpenConnect's `--external-browser` (needs openconnect ≥ 9.0)
 - **Background or foreground** execution, per your config
 
@@ -230,6 +231,20 @@ vpn-up stop                        # stop the VPN (or: stop "Frankfurt VPN")
 ```
 
 Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so `status`, `stop`, and `logs` are profile-aware.
+
+### TOTP authenticator-app 2FA
+
+For gateways that prompt for a time-based one-time code (Google Authenticator, Authy, a hardware TOTP token), store the base32 seed once and `vpn-up` generates the current code at connect time:
+
+```bash
+vpn-up set-secret "Work VPN" token_secret   # paste the base32 seed
+```
+
+…then set `<tokenMode>totp</tokenMode>` on the profile (the `add-profile` wizard offers this as a 2FA choice). Requires **`oathtool`** (`brew install oath-toolkit` / `apt install oathtool`; shown by `vpn-up doctor`).
+
+- The **seed stays in your keychain** — it's never passed to openconnect's argv or written to disk; only the short-lived 6-digit code is sent (on stdin), the same path as a Duo passcode.
+- Because no interaction is needed, a TOTP profile is the **one 2FA method that can run as a login service** with auto-reconnect (Duo passcode and SSO can't).
+- Security note: storing the TOTP seed beside the password in the same keychain is effectively "1.5-factor" — it's opt-in.
 
 ### SSO / external-browser login
 
@@ -396,7 +411,7 @@ Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2
 
 **Under consideration** (open an issue if you need one of these):
 
-- TOTP / RSA token support via openconnect's native `--token-mode`
+- RSA SecurID / Yubikey OATH token support (TOTP is already supported — see [SSO & 2FA](#sso--external-browser-login))
 - HTTP/SOCKS proxy passthrough as a profile field
 - Multiple simultaneous tunnels (per-profile state files already lay the groundwork)
 

--- a/completions/vpn-up.bash
+++ b/completions/vpn-up.bash
@@ -41,7 +41,7 @@ _vpn_up() {
       if [ "$COMP_CWORD" -eq 2 ]; then
         _vpn_up_complete_profiles "$cur"
       elif [ "$COMP_CWORD" -eq 3 ]; then
-        mapfile -t COMPREPLY < <(compgen -W "password" -- "$cur")
+        mapfile -t COMPREPLY < <(compgen -W "password token_secret" -- "$cur")
       fi
       ;;
     logs)

--- a/config/vpn-up.command.profiles.default
+++ b/config/vpn-up.command.profiles.default
@@ -24,6 +24,10 @@
              an embedded Duo iframe. Requires openconnect >= 9.0; runs in the
              foreground and cannot run as a login service. -->
         <authMode>password</authMode>
+        <!-- tokenMode: empty (default) or totp for an authenticator-app code.
+             The TOTP secret is stored in the secrets backend, not here:
+             vpn-up set-secret "<profile name>" token_secret  (needs oathtool). -->
+        <tokenMode></tokenMode>
     </VPN>
 
     <!-- VPN PROFILE 2 -->
@@ -40,6 +44,10 @@
         <serverCertificate></serverCertificate> <!-- SHA1 -->
         <!-- authMode options are the same as for VPN PROFILE 1 -->
         <authMode>password</authMode>
+        <!-- tokenMode: empty (default) or totp for an authenticator-app code.
+             The TOTP secret is stored in the secrets backend, not here:
+             vpn-up set-secret "<profile name>" token_secret  (needs oathtool). -->
+        <tokenMode></tokenMode>
     </VPN>
     <!-- Add more VPN profiles as needed -->
 </VPNs>

--- a/core.sh
+++ b/core.sh
@@ -193,9 +193,33 @@ connect() {
     require_openconnect_sso || return 1
   fi
 
+  # TOTP authenticator-app 2FA: generate the current one-time code from a seed
+  # stored in the secrets backend and feed it as the second auth line (same path
+  # as a Duo passcode). The seed never reaches openconnect's argv or disk, and
+  # because no interaction is needed it works as a non-interactive service too.
+  VPN_SECOND_FACTOR=""
+  if [ "${VPN_AUTH_MODE:-password}" != sso ] && [ "$VPN_TOKEN_MODE" = totp ]; then
+    require_oathtool || return 1
+    local seed; seed="$(secrets_get "${VPN_NAME}" token_secret)"
+    if [ -z "$seed" ]; then
+      if [ -n "${VPN_UP_SERVICE:-}" ]; then
+        print_danger "No TOTP secret stored for '%s' and service mode cannot prompt. Store it first: %s set-secret '%s' token_secret\n" "${VPN_NAME}" "${DISPLAY_NAME}" "${VPN_NAME}"
+        return 1
+      fi
+      read -r -s -p "Enter the TOTP secret (base32) for ${VPN_NAME}: " seed; echo
+      [ -n "$seed" ] && secrets_set "${VPN_NAME}" token_secret "$seed"
+    fi
+    VPN_SECOND_FACTOR="$(generate_totp "$seed")"
+    unset seed
+    if [ -z "$VPN_SECOND_FACTOR" ]; then
+      print_danger "Could not generate a TOTP code (check the stored secret with: %s set-secret '%s' token_secret).\n" "${DISPLAY_NAME}" "${VPN_NAME}"
+      return 1
+    fi
+  fi
+
   # Duo passcodes are one-time values; never read them from the XML —
-  # prompt at connect time instead. (Skipped for SSO: the browser handles MFA.)
-  if [ "${VPN_AUTH_MODE:-password}" != sso ] && [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
+  # prompt at connect time instead. (Skipped for SSO and TOTP token mode.)
+  if [ "${VPN_AUTH_MODE:-password}" != sso ] && [ "$VPN_TOKEN_MODE" != totp ] && [ "$VPN_DUO2FAMETHOD" = "passcode" ]; then
     if [ -n "${VPN_UP_SERVICE:-}" ]; then
       print_danger "Profile '%s' uses a Duo passcode, which needs interactive input; it cannot run as a service. Use push/phone/sms instead.\n" "${VPN_NAME}"
       return 1
@@ -228,6 +252,8 @@ connect() {
   print_primary "Starting the %s on %s using %s ...\n" "${VPN_NAME}" "${VPN_HOST}" "${PROTOCOL_DESCRIPTION}"
   if [ "${VPN_AUTH_MODE:-password}" = sso ]; then
     print_primary "Connecting via SSO (external browser) — complete the login in the window that opens ...\n"
+  elif [ "$VPN_TOKEN_MODE" = totp ]; then
+    print_primary "Connecting with a TOTP authenticator code ...\n"
   elif [ -z "$VPN_DUO2FAMETHOD" ]; then
     print_warning "Connecting without 2FA (%s) ...\n" "${VPN_DUO2FAMETHOD_DESCRIPTION}"
   else
@@ -349,6 +375,13 @@ resolve_external_browser() {
   [ "$(uname)" = Darwin ] && printf 'open' || printf 'xdg-open'
 }
 
+# Generate the current RFC 6238 TOTP code from a base32 seed. The seed comes from
+# the secrets backend and is passed as an argument here (a local shell var), never
+# to openconnect — only the short-lived code transits (on stdin).
+generate_totp() {
+  oathtool --totp -b "$1" 2>/dev/null
+}
+
 run_openconnect() {
   # Validate sudo up-front on the TTY so the prompt doesn't collide with the
   # password pipe below. For passwordless use, configure a scoped sudoers rule
@@ -392,12 +425,15 @@ run_openconnect() {
   ( umask 077; mkdir -p "${DATA_DIR}/logs" "${DATA_DIR}/pids" )
   chmod 700 "${DATA_DIR}/logs" "${DATA_DIR}/pids"
 
-  # Feed password (and 2FA answer, if any) on stdin. Create the log file as
-  # the unprivileged user with 600 perms and capture openconnect's stderr too
-  # (previously `sudo tee ... 2>&1` redirected tee's stderr, not openconnect's,
-  # and left a root-owned log in the user's directory).
+  # Feed password (and the 2FA answer, if any) on stdin. The second factor is a
+  # generated TOTP code (VPN_SECOND_FACTOR) when token mode is active, otherwise
+  # the Duo method/passcode. Either way it goes on stdin — never on argv. Create
+  # the log file as the unprivileged user with 600 perms and capture openconnect's
+  # stderr too (previously `sudo tee ... 2>&1` redirected tee's stderr, not
+  # openconnect's, and left a root-owned log in the user's directory).
   local stdin_lines="$VPN_PASSWD"
-  [ -n "$VPN_DUO2FAMETHOD" ] && stdin_lines+=$'\n'"$VPN_DUO2FAMETHOD"
+  local second="${VPN_SECOND_FACTOR:-$VPN_DUO2FAMETHOD}"
+  [ -n "$second" ] && stdin_lines+=$'\n'"$second"
   ( umask 077; : > "$LOG_FILE_PATH" )
   if [ "${VPN_AUTH_MODE:-password}" = sso ]; then
     # SSO: openconnect opens a browser and needs the controlling TTY, so pipe
@@ -444,6 +480,7 @@ run_openconnect() {
     run_hooks disconnected "${VPN_NAME:-}" "${VPN_HOST:-}"
   fi
 
-  # Drop the password from shell memory as soon as it has been piped.
-  unset VPN_PASSWD stdin_lines
+  # Drop the password and any generated 2FA code from shell memory as soon as
+  # they have been piped.
+  unset VPN_PASSWD stdin_lines second VPN_SECOND_FACTOR
 }

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -31,6 +31,16 @@ require_openconnect_sso() {
   return 0
 }
 
+# TOTP profiles need `oathtool` (oath-toolkit) to generate the one-time code.
+# Gate only the TOTP path so non-TOTP users aren't required to install it.
+require_oathtool() {
+  if ! command -v oathtool >/dev/null 2>&1; then
+    print_danger "TOTP 2FA needs 'oathtool'. Install via: brew install oath-toolkit | apt-get install oathtool\n"
+    return 1
+  fi
+  return 0
+}
+
 check_dependencies() {
   require_bin xmlstarlet "Install via: brew install xmlstarlet | apt-get install xmlstarlet"
   require_bin openconnect "Install via: brew install openconnect | apt-get install openconnect"
@@ -70,6 +80,11 @@ doctor() {
     else
       echo "  [..] SSO / external browser needs openconnect >= 9.0 (detected: ${_ocmaj:-unknown})"
     fi
+  fi
+  if command -v oathtool >/dev/null 2>&1; then
+    echo "  [OK] oathtool -> $(command -v oathtool) (TOTP 2FA supported)"
+  else
+    echo "  [..] oathtool not found (needed only for TOTP 2FA: brew install oath-toolkit | apt-get install oathtool)"
   fi
   if [ "$(uname)" = "Darwin" ]; then
     if command -v security >/dev/null 2>&1; then echo "  [OK] security (Keychain)"; else echo "  [!!] security missing"; fi

--- a/docs/sso-duo.md
+++ b/docs/sso-duo.md
@@ -29,6 +29,27 @@ AuthGroup selection don't collide:
 vpn-up start "Work VPN"   # connect; approve the Duo push when prompted
 ```
 
+## TOTP authenticator-app codes (Google Authenticator, Authy, hardware tokens)
+
+If your gateway prompts for a time-based one-time code, store the base32 seed
+once and VPN Up generates the current code at connect time:
+
+```bash
+vpn-up set-secret "Work VPN" token_secret   # paste the base32 seed
+```
+
+Set `<tokenMode>totp</tokenMode>` on the profile (the `add-profile` wizard offers
+it as a 2FA choice). Requires **`oathtool`** (`brew install oath-toolkit` /
+`apt install oathtool`; reported by `vpn-up doctor`).
+
+- The **seed stays in your keychain** — it's never passed to OpenConnect's command
+  line or written to disk. Only the short-lived 6-digit code is sent, on stdin.
+- TOTP needs no interaction, so it's the **one 2FA method that can run as a
+  [login service]({{ '/vpn-at-login/' | relative_url }})** with auto-reconnect —
+  ideal for headless servers. (Duo passcode and SSO can't, since they need a human.)
+- Security note: keeping the seed beside the password in one keychain is
+  effectively "1.5-factor" — it's opt-in.
+
 ## Browser-based SSO (Okta, Azure AD, Ping Identity)
 
 For gateways that require an external browser login, mark the profile with

--- a/docs/vpn-at-login.md
+++ b/docs/vpn-at-login.md
@@ -37,9 +37,11 @@ Because there's no terminal to type into at login, a service profile needs:
    ```
 
 2. **A stored password** — `vpn-up set-secret "Work VPN" password`.
-3. **A non-interactive 2FA method** — `push`, `phone`, or `sms`. Duo `passcode` and
-   [browser SSO]({{ '/sso-duo/' | relative_url }}) profiles are **refused**, since
-   both need interaction.
+3. **A non-interactive 2FA method** — `push`, `phone`, `sms`, or a
+   [TOTP authenticator]({{ '/sso-duo/' | relative_url }}#totp-authenticator-app-codes-google-authenticator-authy-hardware-tokens)
+   (the code is generated from the stored seed, so it's the ideal fit). Duo
+   `passcode` and [browser SSO]({{ '/sso-duo/' | relative_url }}) profiles are
+   **refused**, since both need a human.
 
 `vpn-up service install` runs these preflight checks and warns you if anything is missing.
 

--- a/profiles.sh
+++ b/profiles.sh
@@ -32,7 +32,8 @@ load_profile_fields() {
       -v "password" -n \
       -v "duo2FAMethod | duoMethod" -n \
       -v "serverCertificate" -n \
-      -v "authMode | authmode" -n "${PROFILES_FILE}"
+      -v "authMode | authmode" -n \
+      -v "tokenMode | tokenmode" -n "${PROFILES_FILE}"
   )
   VPN_NAME="${fields[0]:-}"
   PROTOCOL="${fields[1]:-}"
@@ -45,6 +46,8 @@ load_profile_fields() {
   # Authentication mode: 'sso' (browser-based SAML/SSO) or 'password' (default).
   VPN_AUTH_MODE="$(printf '%s' "${fields[8]:-password}" | tr '[:upper:]' '[:lower:]')"
   if [ -z "$VPN_AUTH_MODE" ]; then VPN_AUTH_MODE=password; fi
+  # Software-token 2FA: 'totp' generates the one-time code from a stored seed.
+  VPN_TOKEN_MODE="$(printf '%s' "${fields[9]:-}" | tr '[:upper:]' '[:lower:]')"
 
   # Intentionally NOT exported: these are read only by functions in this
   # shell, and exporting would copy the password into the environment of
@@ -112,10 +115,12 @@ list_profiles() {
       -v protocol -o $'\t' \
       -v host -o $'\t' \
       -v 'duo2FAMethod | duoMethod' -o $'\t' \
-      -v 'authMode | authmode' -n "$PROFILES_FILE" \
+      -v 'authMode | authmode' -o $'\t' \
+      -v 'tokenMode | tokenmode' -n "$PROFILES_FILE" \
     | awk -F'\t' '
         BEGIN { printf "%-25s %-11s %-35s %-9s %s\n", "NAME", "PROTOCOL", "HOST", "2FA", "AUTH" }
-        { printf "%-25s %-11s %-35s %-9s %s\n", $1, ($2==""?"-":$2), ($3==""?"-":$3), ($4==""?"-":$4), ($5==""?"password":$5) }'
+        { twofa = ($6!="" ? $6 : ($4=="" ? "-" : $4));
+          printf "%-25s %-11s %-35s %-9s %s\n", $1, ($2==""?"-":$2), ($3==""?"-":$3), twofa, ($5==""?"password":$5) }'
 }
 
 # shellcheck disable=SC2034  # description vars are consumed by core.sh

--- a/service.sh
+++ b/service.sh
@@ -114,6 +114,17 @@ _service_preflight() {
     print_danger "Profile '%s' uses a Duo passcode (interactive); it cannot run as a service.\n" "$profile"
     return 1
   fi
+  # TOTP is non-interactive (the code is generated from a stored seed), so it CAN
+  # run as a service — but only if the seed is stored and oathtool is available.
+  local tokenmode
+  tokenmode="$(xmlstarlet sel -t -m "//VPN[name=$(xpath_literal "$profile")]" -v 'tokenMode | tokenmode' "$PROFILES_FILE" 2>/dev/null)"
+  if [ "$tokenmode" = totp ]; then
+    if [ -z "$(secrets_get "$profile" "token_secret" 2>/dev/null)" ]; then
+      print_danger "Profile '%s' uses TOTP but has no stored secret; a service can't prompt. Store it first: %s set-secret '%s' token_secret\n" "$profile" "${DISPLAY_NAME}" "$profile"
+      return 1
+    fi
+    command -v oathtool >/dev/null 2>&1 || print_warning "'oathtool' not found; the TOTP service will fail until it's installed (brew install oath-toolkit | apt-get install oathtool).\n"
+  fi
   return 0
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ CFG
 # Append a <VPN> block to the profiles file (password stays empty — secrets
 # belong in the secrets backend, set separately).
 append_profile() {
-  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}"
+  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}"
   local tmp="${PROFILES_FILE}.tmp"
   xmlstarlet ed \
     -s '/VPNs' -t elem -n VPN -v '' \
@@ -73,6 +73,7 @@ append_profile() {
     -s '/VPNs/VPN[last()]' -t elem -n duo2FAMethod -v "$duo" \
     -s '/VPNs/VPN[last()]' -t elem -n serverCertificate -v '' \
     -s '/VPNs/VPN[last()]' -t elem -n authMode -v "$authmode" \
+    -s '/VPNs/VPN[last()]' -t elem -n tokenMode -v "$tokenmode" \
     "${PROFILES_FILE}" > "${tmp}" && mv "${tmp}" "${PROFILES_FILE}" && chmod 600 "${PROFILES_FILE}"
 }
 
@@ -81,7 +82,7 @@ add_profile_wizard() {
     ( umask 077; printf '<VPNs>\n</VPNs>\n' > "$PROFILES_FILE" )
   fi
 
-  local name proto host group user duo authmode
+  local name proto host group user duo authmode tokenmode
   read -r -p "Profile name: " name
   [ -n "$name" ] || { print_danger "Profile name is required.\n"; return 1; }
   if profile_exists "$name"; then
@@ -102,9 +103,9 @@ add_profile_wizard() {
   read -r -p "Username: " user
 
   # SSO / browser-based login (Okta, Azure AD, Ping + embedded Duo). When on,
-  # credentials and MFA are entered in the browser, so skip the Duo-method and
-  # password prompts entirely.
-  authmode=password; duo=""
+  # credentials and MFA are entered in the browser, so skip the 2FA and password
+  # prompts entirely.
+  authmode=password; duo=""; tokenmode=""
   local _in_sso=""
   read -r -p "Use SSO / browser-based login (Okta, Azure AD, Ping + Duo)? [y/N]: " _in_sso
   if [ "$(_bool_default "${_in_sso}" "FALSE")" = TRUE ]; then
@@ -114,10 +115,29 @@ add_profile_wizard() {
     fi
     authmode=sso
   else
-    read -r -p "Duo 2FA method (push/phone/sms/passcode; empty = gateway default): " duo
+    # Choose the 2FA style: Duo, a TOTP authenticator app, or none.
+    local _in_2fa=""
+    read -r -p "Two-factor — (d) Duo, (t) TOTP authenticator app, (n) none [d]: " _in_2fa
+    case "$(printf '%s' "${_in_2fa:-d}" | tr '[:upper:]' '[:lower:]')" in
+      t|totp)
+        tokenmode=totp
+        local _seed=""
+        read -r -s -p "Enter the TOTP secret (base32, from your authenticator app): " _seed; echo
+        if [ -n "$_seed" ]; then
+          if command -v oathtool >/dev/null 2>&1 && [ -n "$(oathtool --totp -b "$_seed" 2>/dev/null)" ]; then
+            secrets_set "$name" "token_secret" "$_seed" && print_success "TOTP secret stored securely.\n"
+          else
+            print_danger "That doesn't look like a valid base32 TOTP secret (or 'oathtool' is missing); not stored. Add it later with: %s set-secret '%s' token_secret\n" "${DISPLAY_NAME}" "$name"
+          fi
+          unset _seed
+        fi
+        ;;
+      n|none|"") : ;;
+      *) read -r -p "Duo 2FA method (push/phone/sms/passcode; empty = gateway default): " duo ;;
+    esac
   fi
 
-  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" \
+  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" \
     || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
   print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
 

--- a/tests/totp.bats
+++ b/tests/totp.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# Tests for TOTP authenticator-app 2FA (tokenMode=totp).
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { printf -- "$1" "${@:2}"; }
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_success() { printf -- "$1" "${@:2}"; }
+  print_primary() { printf -- "$1" "${@:2}"; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../dependencies.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+_write_profiles() {
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>Token VPN</name><protocol>anyconnect</protocol><host>t.example.com</host><authGroup></authGroup><user>alice</user><password></password><duo2FAMethod></duo2FAMethod><serverCertificate></serverCertificate><authMode>password</authMode><tokenMode>totp</tokenMode></VPN>
+  <VPN><name>Duo VPN</name><protocol>anyconnect</protocol><host>d.example.com</host><authGroup></authGroup><user>bob</user><password></password><duo2FAMethod>push</duo2FAMethod><serverCertificate></serverCertificate></VPN>
+</VPNs>
+XML
+}
+
+# --- schema ---
+
+@test "load_profile_fields reads tokenMode=totp and leaves earlier fields intact" {
+  _write_profiles
+  load_profile_fields "Token VPN"
+  [ "$VPN_NAME" = "Token VPN" ]
+  [ "$VPN_USER" = "alice" ]
+  [ "$VPN_AUTH_MODE" = "password" ]
+  [ "$VPN_TOKEN_MODE" = "totp" ]
+}
+
+@test "load_profile_fields leaves tokenMode empty when the tag is absent" {
+  _write_profiles
+  load_profile_fields "Duo VPN"
+  [ -z "$VPN_TOKEN_MODE" ]
+  [ "$VPN_DUO2FAMETHOD" = "push" ]
+}
+
+# --- generation + dependency gate ---
+
+@test "generate_totp returns the oathtool output" {
+  oathtool() { echo "654321"; }
+  [ "$(generate_totp JBSWY3DPEHPK3PXP)" = "654321" ]
+}
+
+@test "require_oathtool succeeds when oathtool is present" {
+  oathtool() { :; }   # a function makes `command -v oathtool` resolve
+  run require_oathtool
+  [ "$status" -eq 0 ]
+}
+
+@test "require_oathtool fails when oathtool is absent" {
+  local saved="$PATH"
+  PATH="/nonexistent"               # no oathtool on PATH, and no stub function
+  run require_oathtool
+  PATH="$saved"
+  [ "$status" -ne 0 ]
+}
+
+# --- the security-critical path: code on stdin, seed never on argv ---
+
+@test "connect (totp) feeds the generated code on stdin and never puts the seed/token flags on argv" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv" stdin="$BATS_TEST_TMPDIR/stdin"
+  oathtool() { echo "424242"; }                       # fixed code
+  secrets_get() { echo "JBSWY3DPEHPK3PXP"; }           # stored seed
+  sudo() {
+    if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$argv"; cat > "$stdin"; return 0; fi
+    return 0   # sudo -v
+  }
+  load_profile_fields "Token VPN"
+  VPN_PASSWD="s3cret"
+  SERVER_CERTIFICATE="pin-sha256:abc"   # skip trust-store lookup
+  QUIET=FALSE; BACKGROUND=TRUE          # use the background branch (no tee/sleep)
+
+  connect
+
+  # stdin: line 1 = password, line 2 = the generated TOTP code
+  [ "$(sed -n 1p "$stdin")" = "s3cret" ]
+  [ "$(sed -n 2p "$stdin")" = "424242" ]
+  # argv: password-on-stdin, but NEVER the token flags or the seed
+  grep -qF -- "--passwd-on-stdin" "$argv"
+  ! grep -qiE -- "--token-(secret|mode)" "$argv"
+  ! grep -qF -- "JBSWY3DPEHPK3PXP" "$argv"
+}
+
+# --- precedence: SSO wins over token (token branch is skipped) ---
+
+@test "connect (sso + totp) takes the SSO path and never generates a TOTP code" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv"
+  require_openconnect_sso() { return 0; }
+  oathtool() { touch "$BATS_TEST_TMPDIR/oathtool-called"; echo "000000"; }
+  sleep() { :; }
+  tee() { cat >/dev/null; }
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$argv"; return 0; fi; return 0; }
+  load_profile_fields "Token VPN"
+  VPN_AUTH_MODE=sso                      # force SSO on top of tokenMode=totp
+  VPN_PASSWD=""
+  SERVER_CERTIFICATE="pin-sha256:abc"
+  QUIET=FALSE; BACKGROUND=FALSE
+  VPN_UP_EXTERNAL_BROWSER="my-opener"
+
+  connect
+
+  grep -qF -- "--external-browser=my-opener" "$argv"
+  ! grep -qF -- "--passwd-on-stdin" "$argv"
+  [ ! -e "$BATS_TEST_TMPDIR/oathtool-called" ]   # token branch was skipped
+}
+
+# --- service mode ---
+
+@test "service preflight allows a TOTP profile with a stored secret, rejects it without one" {
+  _write_profiles
+  source "$BATS_TEST_DIRNAME/../service.sh"
+  sudo() { return 0; }
+  oathtool() { :; }
+
+  secrets_get() { echo "JBSWY3DPEHPK3PXP"; }   # seed present
+  run _service_preflight "Token VPN"
+  [ "$status" -eq 0 ]
+
+  secrets_get() { echo ""; }                   # seed missing
+  run _service_preflight "Token VPN"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no stored secret"* || "$output" == *"set-secret"* ]]
+}


### PR DESCRIPTION
## Summary

Adds **TOTP authenticator-app 2FA** for gateways that prompt for a time-based code (Google Authenticator / Authy / hardware TOTP) — the one openconnect-sso-style capability worth adopting, and previously on the roadmap.

**Design — generate the code ourselves, not `--token-mode`.** OpenConnect's native `--token-secret` can only be passed on the command line (process table) or in a file (disk) — the manual confirms there's no stdin/env option, both of which break vpn-up's secret-hygiene rules. Instead, the base32 **seed lives in the keychain**, and vpn-up generates the current code with `oathtool` at connect time, feeding it as the 2FA answer on stdin (the same path as a Duo passcode). Only the short-lived code transits.

**Payoff:** TOTP is fully non-interactive, so unlike Duo-passcode and SSO a TOTP profile **can run as a login service with auto-reconnect** — the headless-server win.

## What's included
- **Schema:** `<tokenMode>` appended last (index 9; seed stored as the `token_secret` secret, not in XML). `totp` shown in `vpn-up list`.
- **connect():** token branch with precedence `sso → token → duo → plain`; `generate_totp` helper.
- **run_openconnect():** feeds the code via a dedicated var; **never** adds `--token-secret`/`--token-mode`.
- **dependencies:** `require_oathtool` (TOTP path only) + `doctor` surfacing.
- **Wizard:** `add-profile` 2FA choice (Duo / TOTP / none); stores + validates the seed.
- **Service preflight:** **allows** TOTP (requires a stored seed; warns if `oathtool` missing).
- **Docs/tests:** README + docs site (2FA + login-service pages) + CHANGELOG + roadmap; `tests/totp.bats` (8) including a **security assertion that the seed never appears on argv**.

**Scope:** TOTP only — HOTP (counter state) and RSA/Yubikey (need native token-mode) noted as future.

## Test plan
- [ ] CI green (shellcheck + bats on macOS + Ubuntu + gitleaks)
- Local: 89 bats tests pass; shellcheck clean; verified real `oathtool` codes, `list`/`doctor`/wizard end-to-end.

## Note
Storing the seed beside the password in one keychain is "1.5-factor" — documented, opt-in.