### PR TITLE
Add per-profile extra openconnect args passthrough (<extraArgs>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
   it needs no interaction, a TOTP profile **can run as a login service with
   auto-reconnect** (unlike Duo-passcode and SSO). New `oathtool` dependency
   (TOTP only); surfaced by `doctor`; shown in `vpn-up list`.
+- **Extra openconnect arguments** per profile (`<extraArgs>`, also an optional
+  prompt in `add-profile`). Power-user passthrough for flags vpn-up doesn't model
+  (`--no-dtls`, `--os=win`, `--csd-wrapper`, proxies, MTU, …). Tokenized with
+  `xargs` so quotes are respected without `eval`; appended verbatim before the
+  gateway host. Duplicating a flag vpn-up already manages prints a warning but is
+  still passed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,18 @@ Prints the gateway's `pin-sha256:...` value for `<serverCertificate>`, or saves 
 vpn-up doctor
 ```
 
+### Advanced: extra openconnect arguments
+
+Need an openconnect flag `vpn-up` doesn't model (`--no-dtls`, `--os=win`, `--csd-wrapper`, an HTTP/SOCKS proxy, MTU, `--reconnect-timeout`, …)? Set `<extraArgs>` on the profile (or answer the optional "Extra openconnect arguments" prompt in `add-profile`); the value is appended verbatim to the openconnect command, just before the gateway host:
+
+```xml
+<extraArgs>--no-dtls --reconnect-timeout 30</extraArgs>
+```
+
+- Tokenized with `xargs`, so quotes are respected (`"--csd-wrapper=/path with space"` stays one argument) — and **never** `eval`'d.
+- Avoid flags `vpn-up` already manages — `--protocol`, `--user`, `--passwd-on-stdin`, `--background`, `--servercert`, `--authgroup`, `--pid-file`, `--external-browser`, `--token-mode`/`--token-secret`. Duplicating one prints a warning (it may conflict) but is still passed.
+- ⚠️ openconnect runs as **root**; some flags execute programs as root (e.g. `--csd-wrapper`, `--script`). Only put flags here that you'd be comfortable running under `sudo` yourself.
+
 ---
 
 ## ⚙️ Configuration
@@ -399,11 +411,13 @@ Seeded from [config/vpn-up.command.profiles.default](config/vpn-up.command.profi
     <duo2FAMethod>push</duo2FAMethod>
     <serverCertificate>pin-sha256:BASE64_HASH</serverCertificate>
     <authMode>password</authMode>
+    <tokenMode>totp</tokenMode>
+    <extraArgs>--no-dtls</extraArgs>
   </VPN>
 </VPNs>
 ```
 
-Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login).
+Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login). `<tokenMode>` is empty (default) or `totp` for [authenticator-app 2FA](#totp-authenticator-app-2fa). `<extraArgs>` passes extra openconnect flags verbatim — see [Advanced: extra openconnect arguments](#advanced-extra-openconnect-arguments).
 
 ---
 

--- a/config/vpn-up.command.profiles.default
+++ b/config/vpn-up.command.profiles.default
@@ -28,6 +28,13 @@
              The TOTP secret is stored in the secrets backend, not here:
              vpn-up set-secret "<profile name>" token_secret  (needs oathtool). -->
         <tokenMode></tokenMode>
+        <!-- extraArgs (advanced): extra openconnect flags passed verbatim, e.g.
+             --no-dtls, --os=win, --csd-wrapper=/path. Quotes are respected.
+             Avoid flags vpn-up already manages (--protocol, --user, --pid-file,
+             --passwd-on-stdin, --background, --servercert, --authgroup, …).
+             NOTE: openconnect runs as root — some flags (e.g. --csd-wrapper,
+             --script) execute programs as root. -->
+        <extraArgs></extraArgs>
     </VPN>
 
     <!-- VPN PROFILE 2 -->
@@ -48,6 +55,13 @@
              The TOTP secret is stored in the secrets backend, not here:
              vpn-up set-secret "<profile name>" token_secret  (needs oathtool). -->
         <tokenMode></tokenMode>
+        <!-- extraArgs (advanced): extra openconnect flags passed verbatim, e.g.
+             --no-dtls, --os=win, --csd-wrapper=/path. Quotes are respected.
+             Avoid flags vpn-up already manages (--protocol, --user, --pid-file,
+             --passwd-on-stdin, --background, --servercert, --authgroup, …).
+             NOTE: openconnect runs as root — some flags (e.g. --csd-wrapper,
+             --script) execute programs as root. -->
+        <extraArgs></extraArgs>
     </VPN>
     <!-- Add more VPN profiles as needed -->
 </VPNs>

--- a/core.sh
+++ b/core.sh
@@ -382,6 +382,19 @@ generate_totp() {
   oathtool --totp -b "$1" 2>/dev/null
 }
 
+# Warn (but don't block) when a user-supplied extra arg duplicates a flag that
+# vpn-up already manages — overriding these can break connection or status/stop.
+_warn_extra_arg_collisions() {
+  local tok base
+  for tok in "$@"; do
+    base="${tok%%=*}"
+    case "$base" in
+      --protocol|-q|--user|--passwd-on-stdin|--background|--servercert|--authgroup|--pid-file|--external-browser|--token-mode|--token-secret)
+        print_warning "extraArgs contains '%s', which vpn-up already manages; passing it anyway (may conflict).\n" "$base" ;;
+    esac
+  done
+}
+
 run_openconnect() {
   # Validate sudo up-front on the TTY so the prompt doesn't collide with the
   # password pipe below. For passwordless use, configure a scoped sudoers rule
@@ -418,6 +431,20 @@ run_openconnect() {
   [ "$effective_background" = TRUE ] && args+=(--background)
   [ -n "$SERVER_CERTIFICATE" ] && args+=(--servercert="$SERVER_CERTIFICATE")
   [ -n "$VPN_GROUP" ] && args+=(--authgroup "$VPN_GROUP")
+  # Extra user-supplied openconnect args (advanced). Tokenized with xargs so
+  # quotes are respected without eval; appended verbatim before the host.
+  if [ -n "${VPN_EXTRA_ARGS:-}" ]; then
+    local _extra=() _split _rc
+    _split="$(printf '%s\n' "$VPN_EXTRA_ARGS" | xargs -n1 2>/dev/null)"; _rc=$?
+    if [ "$_rc" -ne 0 ]; then
+      print_warning "Ignoring extraArgs for '%s' (malformed quoting).\n" "$VPN_NAME"
+    else
+      mapfile -t _extra <<< "$_split"
+      [ "${#_extra[@]}" -eq 1 ] && [ -z "${_extra[0]}" ] && _extra=()
+      [ "${#_extra[@]}" -gt 0 ] && _warn_extra_arg_collisions "${_extra[@]}"
+      [ "${#_extra[@]}" -gt 0 ] && args+=("${_extra[@]}")
+    fi
+  fi
   args+=("$VPN_HOST")
   args+=(--pid-file "$PID_FILE_PATH")
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,5 +79,24 @@ Drop executable scripts in `~/.config/vpn-up/hooks/connected.d/` or
 proxies). Hooks receive `VPN_EVENT`, `VPN_NAME`, and `VPN_HOST` — never the
 password — and are skipped unless owned by you and not group/world-writable.
 
+## Advanced: extra openconnect arguments
+
+For a flag VPN Up doesn't model (`--no-dtls`, `--os=win`, `--csd-wrapper`, an
+HTTP/SOCKS proxy, MTU, `--reconnect-timeout`, …), set `<extraArgs>` on the profile
+(or use the optional prompt in `add-profile`). The value is appended verbatim to
+the openconnect command, just before the gateway host:
+
+```xml
+<extraArgs>--no-dtls --reconnect-timeout 30</extraArgs>
+```
+
+- Tokenized with `xargs`, so quotes are respected (`"--csd-wrapper=/path with space"`
+  stays one argument) and the value is **never** `eval`'d.
+- Avoid flags VPN Up already manages (`--protocol`, `--user`, `--passwd-on-stdin`,
+  `--background`, `--servercert`, `--authgroup`, `--pid-file`, `--external-browser`,
+  `--token-mode`/`--token-secret`). Duplicating one warns but is still passed.
+- **openconnect runs as root**, so some flags execute programs as root (e.g.
+  `--csd-wrapper`, `--script`) — only add flags you'd run under `sudo` yourself.
+
 See also: [SSO & Duo 2FA]({{ '/sso-duo/' | relative_url }}) and
 [supported protocols]({{ '/protocols/' | relative_url }}).

--- a/profiles.sh
+++ b/profiles.sh
@@ -33,7 +33,8 @@ load_profile_fields() {
       -v "duo2FAMethod | duoMethod" -n \
       -v "serverCertificate" -n \
       -v "authMode | authmode" -n \
-      -v "tokenMode | tokenmode" -n "${PROFILES_FILE}"
+      -v "tokenMode | tokenmode" -n \
+      -v "extraArgs | extraargs" -n "${PROFILES_FILE}"
   )
   VPN_NAME="${fields[0]:-}"
   PROTOCOL="${fields[1]:-}"
@@ -48,6 +49,8 @@ load_profile_fields() {
   if [ -z "$VPN_AUTH_MODE" ]; then VPN_AUTH_MODE=password; fi
   # Software-token 2FA: 'totp' generates the one-time code from a stored seed.
   VPN_TOKEN_MODE="$(printf '%s' "${fields[9]:-}" | tr '[:upper:]' '[:lower:]')"
+  # Advanced: extra openconnect arguments passed verbatim (tokenized at connect).
+  VPN_EXTRA_ARGS="${fields[10]:-}"
 
   # Intentionally NOT exported: these are read only by functions in this
   # shell, and exporting would copy the password into the environment of

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ CFG
 # Append a <VPN> block to the profiles file (password stays empty — secrets
 # belong in the secrets backend, set separately).
 append_profile() {
-  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}"
+  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}" extraargs="${9:-}"
   local tmp="${PROFILES_FILE}.tmp"
   xmlstarlet ed \
     -s '/VPNs' -t elem -n VPN -v '' \
@@ -74,6 +74,7 @@ append_profile() {
     -s '/VPNs/VPN[last()]' -t elem -n serverCertificate -v '' \
     -s '/VPNs/VPN[last()]' -t elem -n authMode -v "$authmode" \
     -s '/VPNs/VPN[last()]' -t elem -n tokenMode -v "$tokenmode" \
+    -s '/VPNs/VPN[last()]' -t elem -n extraArgs -v "$extraargs" \
     "${PROFILES_FILE}" > "${tmp}" && mv "${tmp}" "${PROFILES_FILE}" && chmod 600 "${PROFILES_FILE}"
 }
 
@@ -82,7 +83,7 @@ add_profile_wizard() {
     ( umask 077; printf '<VPNs>\n</VPNs>\n' > "$PROFILES_FILE" )
   fi
 
-  local name proto host group user duo authmode tokenmode
+  local name proto host group user duo authmode tokenmode extraargs
   read -r -p "Profile name: " name
   [ -n "$name" ] || { print_danger "Profile name is required.\n"; return 1; }
   if profile_exists "$name"; then
@@ -137,7 +138,11 @@ add_profile_wizard() {
     esac
   fi
 
-  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" \
+  # Advanced (optional): extra openconnect flags passed verbatim at connect time.
+  extraargs=""
+  read -r -p "Extra openconnect arguments (advanced, optional): " extraargs
+
+  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" "$extraargs" \
     || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
   print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
 

--- a/tests/extraargs.bats
+++ b/tests/extraargs.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# Tests for the per-profile extraArgs openconnect passthrough.
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { printf -- "$1" "${@:2}"; }
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_success() { printf -- "$1" "${@:2}"; }
+  print_primary() { printf -- "$1" "${@:2}"; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../dependencies.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+# Profile XML with an extraArgs value (quoting included to test tokenization).
+_write_profiles() {
+  local extra="$1"
+  cat > "$PROFILES_FILE" <<XML
+<VPNs>
+  <VPN><name>Extra VPN</name><protocol>anyconnect</protocol><host>x.example.com</host><authGroup></authGroup><user>alice</user><password></password><duo2FAMethod></duo2FAMethod><serverCertificate></serverCertificate><authMode>password</authMode><tokenMode></tokenMode><extraArgs>${extra}</extraArgs></VPN>
+</VPNs>
+XML
+}
+
+# Run run_openconnect (background branch) capturing the openconnect argv.
+_capture_argv() {
+  ARGV_FILE="$BATS_TEST_TMPDIR/argv"
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$ARGV_FILE"; return 0; fi; return 0; }
+  VPN_PASSWD="pw"; SERVER_CERTIFICATE="pin-sha256:abc"
+  QUIET=FALSE; BACKGROUND=TRUE
+  run_openconnect
+}
+
+# --- schema ---
+
+@test "load_profile_fields reads extraArgs (index 10); earlier fields intact" {
+  _write_profiles "--no-dtls"
+  load_profile_fields "Extra VPN"
+  [ "$VPN_NAME" = "Extra VPN" ]
+  [ "$VPN_AUTH_MODE" = "password" ]
+  [ -z "$VPN_TOKEN_MODE" ]
+  [ "$VPN_EXTRA_ARGS" = "--no-dtls" ]
+}
+
+# --- tokenization & placement ---
+
+@test "extraArgs are tokenized (quotes respected) and appended before the host" {
+  _write_profiles '--no-dtls --os=win &quot;--csd-wrapper=/a b&quot;'
+  load_profile_fields "Extra VPN"
+  _capture_argv
+
+  grep -qx -- "--no-dtls" "$ARGV_FILE"
+  grep -qx -- "--os=win" "$ARGV_FILE"
+  grep -qx -- "--csd-wrapper=/a b" "$ARGV_FILE"   # quoted value stays one element
+  # extra args come before the host positional
+  local n_csd n_host
+  n_csd="$(grep -nx -- "--csd-wrapper=/a b" "$ARGV_FILE" | cut -d: -f1)"
+  n_host="$(grep -nx -- "x.example.com" "$ARGV_FILE" | cut -d: -f1)"
+  [ "$n_csd" -lt "$n_host" ]
+}
+
+@test "empty extraArgs adds no stray argument" {
+  _write_profiles ""
+  load_profile_fields "Extra VPN"
+  _capture_argv
+  # no empty line in the captured argv
+  ! grep -qx -- "" "$ARGV_FILE"
+  grep -qx -- "x.example.com" "$ARGV_FILE"
+}
+
+# --- collision warning (warn, but still pass) ---
+
+@test "a managed flag in extraArgs warns but is still passed" {
+  _write_profiles "--pid-file /tmp/x"
+  load_profile_fields "Extra VPN"
+  ARGV_FILE="$BATS_TEST_TMPDIR/argv"
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$ARGV_FILE"; return 0; fi; return 0; }
+  VPN_PASSWD="pw"; SERVER_CERTIFICATE="pin-sha256:abc"; QUIET=FALSE; BACKGROUND=TRUE
+  run run_openconnect
+  [[ "$output" == *"vpn-up already manages"* ]]
+  grep -qx -- "--pid-file" "$ARGV_FILE"     # still passed through
+}
+
+@test "_warn_extra_arg_collisions flags managed flags and ignores others" {
+  run _warn_extra_arg_collisions --no-dtls --user=bob --reconnect-timeout 30
+  [[ "$output" == *"--user"* ]]
+  [[ "$output" != *"--no-dtls"* ]]
+  [[ "$output" != *"--reconnect-timeout"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a per-profile **`<extraArgs>`** field for openconnect flags VPN Up doesn't model (`--no-dtls`, `--os=win`, `--csd-wrapper`, proxies, MTU, `--reconnect-timeout`, …) — the small ergonomic borrow from the openconnect-sso comparison.

- **Tokenized with `xargs`** so quotes are respected (`"--csd-wrapper=/a b"` stays one argument) without `eval` / command substitution / globbing. Appended **verbatim before the gateway host**.
- **Warn-but-pass on collisions:** `_warn_extra_arg_collisions` flags tokens that duplicate a vpn-up-managed flag (`--protocol`, `--passwd-on-stdin`, `--pid-file`, `--external-browser`, …) but still passes them.
- **Wizard:** an optional, skippable "Extra openconnect arguments (advanced)" prompt in `add-profile`.

## What's included
- Schema: `<extraArgs>` appended last (index 10) — profiles.sh + append_profile + default template (with the root/sudo footgun note).
- core.sh: tokenize/warn/append in `run_openconnect`.
- README + docs site "Advanced: extra openconnect arguments" sections; CHANGELOG.
- `tests/extraargs.bats` (5): tokenization incl. quoted values, host placement, empty no-op, collision warning.

## Threat model
openconnect already runs as root via `sudo` with user-controlled config, so this grants no new privilege — it's a documented power-user feature, and tokens become argv elements (never `eval`'d), so there's no shell-injection path via the XML.

## Test plan
- [ ] CI green (shellcheck + bats on macOS + Ubuntu + gitleaks)
- Local: 94 bats tests pass; shellcheck clean; verified the wizard writes `extraArgs` and `list` still works.