### PR TITLE
Release v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
-## [Unreleased]
+## [v3.8.0] — 2026-06-18
+### TOTP 2FA & Argument Passthrough Update
 
 ### Added
 - **TOTP authenticator-app 2FA** (`<tokenMode>totp</tokenMode>`). For gateways

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.7.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.8.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)


### PR DESCRIPTION
## Summary

Cuts **v3.8.0** — ships the two features merged under `[Unreleased]` (#62 TOTP, #63 extraArgs).

- Promote `[Unreleased]` → `[v3.8.0] — 2026-06-18`
- Bump the static README release badge to `v3.8.0`

## What's in v3.8.0

- **TOTP authenticator-app 2FA** (`<tokenMode>totp</tokenMode>`) — seed stays in the keychain, code generated with `oathtool` and fed on stdin (never `--token-secret`); the one 2FA method that runs as a non-interactive auto-reconnecting login service.
- **Extra openconnect arguments** (`<extraArgs>`) — verbatim, quote-respecting (xargs, no `eval`) passthrough for flags vpn-up doesn't model; warns on collision with managed flags.

## Test plan
- [ ] CI green (shellcheck + bats on macOS + Ubuntu + gitleaks)
- [ ] Merge → tag `v3.8.0` → publish release → `release-tap.yml` updates the Homebrew formula