### PR TITLE
Docs: add VPN Up vs. GlobalProtect-openconnect comparison page

### DIFF
--- a/docs/globalprotect-cli.md
+++ b/docs/globalprotect-cli.md
@@ -54,4 +54,5 @@ group/realm, and run `vpn-up doctor` to confirm your OpenConnect version. More
 fixes on the [troubleshooting page]({{ '/troubleshooting/' | relative_url }}).
 
 Related: [supported protocols]({{ '/protocols/' | relative_url }}) ·
-[Cisco AnyConnect CLI alternative]({{ '/anyconnect-cli-alternative/' | relative_url }}).
+[Cisco AnyConnect CLI alternative]({{ '/anyconnect-cli-alternative/' | relative_url }}) ·
+[VPN Up vs. GlobalProtect-openconnect]({{ '/vs-globalprotect-openconnect/' | relative_url }}).

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ See the [installation guide]({{ '/installation/' | relative_url }}) for manual s
 - [Auto-connect a VPN at login]({{ '/vpn-at-login/' | relative_url }}) — launchd (macOS) & systemd (Linux) with auto-reconnect
 - [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}) — what the wrapper adds, and when to use each
 - [VPN Up vs. openconnect-sso]({{ '/vs-openconnect-sso/' | relative_url }}) — two AnyConnect SSO clients compared, fairly
+- [VPN Up vs. GlobalProtect-openconnect]({{ '/vs-globalprotect-openconnect/' | relative_url }}) — two GlobalProtect CLI clients compared
 
 ## Related articles
 

--- a/docs/vs-globalprotect-openconnect.md
+++ b/docs/vs-globalprotect-openconnect.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: VPN Up vs. GlobalProtect-openconnect
+description: >-
+  How VPN Up compares to yuezk/GlobalProtect-openconnect for connecting to Palo
+  Alto GlobalProtect VPNs from the command line — platform support, protocols,
+  free vs. paid GUI, SSO/FIDO2 vs. Duo/TOTP, and auto-reconnect.
+permalink: /vs-globalprotect-openconnect/
+---
+
+# VPN Up vs. GlobalProtect-openconnect
+
+[GlobalProtect-openconnect](https://github.com/yuezk/GlobalProtect-openconnect) is a
+popular, well-packaged **GlobalProtect** VPN client for Linux, written in Rust and
+built on OpenConnect, with both a CLI and a system-tray GUI. VPN Up overlaps with it
+on [GlobalProtect from the command line]({{ '/globalprotect-cli/' | relative_url }}),
+so this page lays out the real differences. (Both are good tools built on the same
+OpenConnect foundation; this aims to be fair, not a pitch.)
+
+## Side by side
+
+| | GlobalProtect-openconnect | VPN Up |
+|---|---|---|
+| Protocols | GlobalProtect **only** | anyconnect, **gp**, pulse, nc |
+| Platforms | **Linux only** (broad distro packaging) | **macOS + Linux** |
+| Language / runtime | Rust + Tauri + `webkit2gtk` | Bash (+ `openconnect`, `xmlstarlet`) |
+| Interface | CLI **and** GUI + system tray | CLI only (terminal-first by design) |
+| License / cost | CLI free (GPL-3.0); **GUI proprietary, paid** (7-day trial) | **Fully free, MIT** — no paid tier |
+| Browser SSO / SAML | Yes (default or specified browser) | Yes (`--external-browser`, needs OpenConnect ≥ 9) |
+| FIDO2 / YubiKey | **Yes** | Not yet (on the roadmap) |
+| Client-certificate auth | Yes | Via `<extraArgs>` (not first-class) |
+| Duo push / phone / sms / passcode | Not the focus | First-class |
+| TOTP authenticator codes | — (uses FIDO2 / SSO instead) | Yes — seed in keychain, code on stdin; works non-interactively |
+| Named profiles + keyring secrets | Portal/gateway config + keyring | Yes (Keychain, Secret Service, or encrypted vault) |
+| Profile-aware `status` / `stop` / `logs` | Tray-driven | Yes, scriptable |
+| Auto-connect / reconnect | Auto-connect on startup (tray) | **Login service (launchd / systemd)** with auto-reconnect |
+| Hooks / notifications / completion / `doctor` | Partial (tray) | Yes |
+| Dependencies | webkit2gtk, libsecret, appindicator, pkexec, keyring | openconnect, xmlstarlet, secret backend (+ `oathtool` for TOTP) |
+| Maintenance | Active (broad packaging) | Active (CI, docs, regular releases) |
+
+## The real differences
+
+**Scope.** GlobalProtect-openconnect is a *GlobalProtect specialist* — deep on one
+protocol, with a native desktop app, a system tray, and packages for nearly every
+Linux distribution. VPN Up is a *multi-protocol generalist* — the same workflow
+whether the gateway speaks Cisco AnyConnect, GlobalProtect, Pulse Secure, or
+Juniper Network Connect.
+
+**Platform.** This is the decisive one for many people: GlobalProtect-openconnect
+is **Linux-only — there is no macOS build**. If you're on a Mac, VPN Up (or
+openconnect-sso for AnyConnect) is the option. If you live on Linux and only use
+GlobalProtect, GlobalProtect-openconnect is purpose-built for you.
+
+**Free vs. paid, and the trust model.** GlobalProtect-openconnect's *CLI* is GPL-3.0
+and free, but its *GUI* is proprietary and requires payment after a 7-day trial. VPN
+Up is entirely MIT and auditable Bash — nothing closed, nothing to pay for, and the
+whole codebase is small enough to read end to end.
+
+**2FA philosophy.** GlobalProtect-openconnect leans on **FIDO2/YubiKey + browser
+SSO** — hardware-token strength, but interactive by nature. VPN Up covers **Duo +
+TOTP + browser SSO**, and crucially its **TOTP path runs non-interactively as a
+login service**: a headless box or laptop can auto-reconnect without a human
+approving each prompt. That's a genuine VPN Up differentiator — at the trade-off
+that the TOTP seed lives in the keychain ("1.5-factor"), which a YubiKey avoids.
+
+## When to choose which
+
+**Choose GlobalProtect-openconnect if** you're on **Linux**, use **GlobalProtect**,
+want a **GUI / system-tray** experience, or need **FIDO2 / YubiKey** — and you're
+fine paying for the GUI (or staying on its free CLI).
+
+**Choose VPN Up if** you need **macOS** support, connect to **more than just
+GlobalProtect**, want a **fully-free, auditable, scriptable** tool, rely on **Duo or
+TOTP**, or want **auto-reconnect at login on a server or laptop** without a GUI. See
+[installation]({{ '/installation/' | relative_url }}) and
+[GlobalProtect from the CLI]({{ '/globalprotect-cli/' | relative_url }}).
+
+> Comparing other clients? See
+> [VPN Up vs. openconnect-sso]({{ '/vs-openconnect-sso/' | relative_url }}) (Cisco
+> AnyConnect SSO) and
+> [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}).

--- a/docs/vs-openconnect-sso.md
+++ b/docs/vs-openconnect-sso.md
@@ -66,4 +66,5 @@ and especially **auto-reconnect on a server or laptop**. See
 [SSO & 2FA]({{ '/sso-duo/' | relative_url }}).
 
 > Not a Cisco AnyConnect / SAML setup? See also
-> [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}).
+> [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}) and
+> [VPN Up vs. GlobalProtect-openconnect]({{ '/vs-globalprotect-openconnect/' | relative_url }}).

--- a/docs/vs-openconnect.md
+++ b/docs/vs-openconnect.md
@@ -58,5 +58,7 @@ OpenConnect supports keeps working.
 Get started: [installation]({{ '/installation/' | relative_url }}) ·
 [usage]({{ '/usage/' | relative_url }}).
 
-> Comparing SSO clients specifically? See
-> [VPN Up vs. openconnect-sso]({{ '/vs-openconnect-sso/' | relative_url }}).
+> Comparing specific clients? See
+> [VPN Up vs. openconnect-sso]({{ '/vs-openconnect-sso/' | relative_url }}) (Cisco
+> AnyConnect SSO) and
+> [VPN Up vs. GlobalProtect-openconnect]({{ '/vs-globalprotect-openconnect/' | relative_url }}).


### PR DESCRIPTION
## Summary

Adds a fair comparison page for the highest-traffic adjacent project,
[yuezk/GlobalProtect-openconnect](https://github.com/yuezk/GlobalProtect-openconnect),
filling the gap alongside the existing `/vs-openconnect/` and `/vs-openconnect-sso/`
pages.

- **New:** `docs/vs-globalprotect-openconnect.md` — side-by-side table + "the real
  differences" (scope, Linux-only vs macOS+Linux, free MIT vs proprietary/paid GUI,
  FIDO2/SSO vs Duo/TOTP) + "when to choose which".
- **Cross-links:** docs index (Guides), the GlobalProtect CLI guide (Related), and
  both sibling comparison pages — keeping the three `vs-` pages mutually linked.

Docs-only; no code, no CHANGELOG entry.

## Verification

- `grep -rn vs-globalprotect-openconnect docs/` resolves from all four referencing pages.
- Unique `permalink` + SEO `title`/`description`; jekyll-seo-tag + sitemap pick it up
  (sitemap gains one page on the next Pages rebuild).
- shellcheck + bats + gitleaks unaffected.