### PR TITLE
Client-certificate authentication (file & PKCS#11 / YubiKey PIV)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — VPN Up for OpenConnect
 
-**Last updated:** 2026-06-18 (v3.8.0)
+**Last updated:** 2026-06-18 (v3.9.0)
 
 > *What* and *why* live in [PRD.md](PRD.md); this document covers *how*. Function and
 > file references are accurate as of the version above — verify against the source
@@ -56,11 +56,11 @@ All modules are sourced by [vpn-up.command](vpn-up.command) in dependency order.
 | **[vpn-up.command](vpn-up.command)** | Entry point. Bash≥4 guard, `set -u`, resolves `PROGRAM_NAME`/`PROGRAM_PATH`/`DATA_DIR`, one-time migration of legacy in-repo state, sources modules, and dispatches the subcommand `case`. Defines `DISPLAY_NAME` indirectly (via logging). |
 | **[logging.sh](logging.sh)** | Paths, print helpers (`print_primary/success/warning/danger`), portable `stat` wrappers (`file_owner_uid`, `file_mode` — GNU `-c` first, BSD `-f` fallback), `profile_slug`, per-profile path setup (`set_profile_paths`), PID helpers (`is_openconnect_pid`, `any_vpn_running`), `show_logs`. Defines `DISPLAY_NAME`. |
 | **[ui.sh](ui.sh)** | ASCII banner (`show_banner`, gated by `SHOW_BANNER` + TTY) and desktop notifications (`notify` → `osascript`/`notify-send`, gated by `NOTIFICATIONS`). |
-| **[dependencies.sh](dependencies.sh)** | `require_bin`, `check_dependencies`, `doctor`. Also `openconnect_major` / `require_openconnect_sso` (the openconnect ≥ 9.0 gate for SSO) and `require_oathtool` (the gate for TOTP). |
+| **[dependencies.sh](dependencies.sh)** | `require_bin`, `check_dependencies`, `doctor`. Also `openconnect_major` / `require_openconnect_sso` (the openconnect ≥ 9.0 gate for SSO) and `require_oathtool` (the gate for TOTP). `doctor` also reports PKCS#11 (`p11-kit`) availability for client certs. |
 | **[encryption.sh](encryption.sh)** | Secret backend abstraction: `secrets_set/get/delete`, `secrets_backend` selection (macOS Keychain via `security -i` stdin; Linux Secret Service via `secret-tool`; OpenSSL AES-256-CBC + PBKDF2 vault fallback). Namespacing via `secrets_key`. |
 | **[network.sh](network.sh)** | Connectivity check, certificate fetch/verify (`fetch_server_pin`, `verify_gateway_cert`), pin save (`pin_save`), `print_pin_instructions`, `print_current_ip_address`. |
 | **[profiles.sh](profiles.sh)** | Profile XML read/validate: `load_profile_fields` (xmlstarlet → shell vars), `xpath_literal` (injection-safe XPath), `list_profiles` (NAME/PROTOCOL/HOST/2FA/AUTH columns), `profile_names_raw`, `profile_exists`, password migration/scrub, protocol/2FA descriptions. |
-| **[core.sh](core.sh)** | Main flow: `start`, `connect`, `run_openconnect`, `status`, `stop`, `write_connection_state`, `run_hooks`, `assert_safe_to_source`, `load_config`, `resolve_external_browser`, `generate_totp`, `_warn_extra_arg_collisions`. |
+| **[core.sh](core.sh)** | Main flow: `start`, `connect`, `run_openconnect`, `status`, `stop`, `write_connection_state`, `run_hooks`, `assert_safe_to_source`, `load_config`, `resolve_external_browser`, `generate_totp`, `_warn_extra_arg_collisions`, `_append_pkcs11_pin_source` (RFC 7512 PIN feed for PKCS#11 client certs). |
 | **[setup.sh](setup.sh)** | Interactive wizards: `setup_wizard`, `add_profile_wizard`, `remove_profile`, `append_profile`, `save_configuration`, `_bool_default`. |
 | **[service.sh](service.sh)** | Login-service mode: launchd plist / systemd unit generation, `service_install/uninstall/status`, `_service_preflight` (rejects passcode + SSO profiles; requires a stored seed for TOTP). |
 | **[completions/vpn-up.bash](completions/vpn-up.bash)** | Bash/zsh completion for commands and profile names. |
@@ -88,10 +88,13 @@ namespace; `DISPLAY_NAME` (`vpn-up`) is used only in user-facing text.
 `name`, `protocol`, `host`, `authGroup` (alias `group`), `user` (alias `username`),
 `password` (deprecated; migrated + blanked), `duo2FAMethod` (alias `duoMethod`),
 `serverCertificate`, `authMode` (`password` default | `sso`), `tokenMode`
-(empty | `totp`), `extraArgs` (verbatim openconnect flags). `load_profile_fields`
-reads them positionally via `mapfile`, so **new fields are appended last** to avoid
-shifting indices (`extraArgs` is index 10). The TOTP **seed** is *not* in the XML —
-it lives in the secrets backend under the `token_secret` field.
+(empty | `totp`), `extraArgs` (verbatim openconnect flags), `clientCertificate` /
+`clientKey` (a file path or a PKCS#11 URI for client-certificate auth).
+`load_profile_fields` reads them positionally via `mapfile`, so **new fields are
+appended last** to avoid shifting indices (`extraArgs` is index 10,
+`clientCertificate`/`clientKey` are 11/12). Secrets are *not* in the XML — the TOTP
+**seed** (`token_secret`) and any client-key **passphrase / PKCS#11 PIN**
+(`key_password`) live in the secrets backend.
 
 ## 5. Key flows
 
@@ -108,6 +111,9 @@ it lives in the secrets backend under the `token_secret` field.
      backend (`token_secret`), and `generate_totp` the current code into
      `VPN_SECOND_FACTOR` (used as the 2FA answer). Non-interactive — allowed in service mode.
    - **Duo passcode** → prompt at connect time (refused in service mode).
+   - **Client certificate** (`clientCertificate`/`clientKey`) is *additive*, not part
+     of the precedence — it applies under any auth mode. `migrate_or_fetch_password`
+     treats a cert-bearing profile with no stored password as cert-only (no prompt).
    - Fail-closed server identity: `pin-sha256` pin, else `verify_gateway_cert`.
 4. **`run_openconnect`** builds the `openconnect` argv array (no `eval`) and invokes
    `sudo openconnect …`:
@@ -118,6 +124,11 @@ it lives in the secrets backend under the `token_secret` field.
      piped to stdin (openconnect keeps the TTY), forced foreground.
    - Per-profile `extraArgs` are tokenized with `xargs` (quote-safe, no `eval`) and
      appended just **before** the host; `_warn_extra_arg_collisions` warns on a managed-flag clash.
+   - **Client cert:** `--certificate=`/`--sslkey=` carry the path or PKCS#11 URI (an
+     identifier, safe on argv). For a `pkcs11:` URI with a stored `key_password`,
+     `_append_pkcs11_pin_source` writes the PIN to a transient `0600` file and adds
+     `pin-source=file:…` to the URI (never the PIN on argv); the file is shredded
+     after the session. A file-key passphrase is left to openconnect's TTY prompt.
    - Background daemonizes (`--background`); foreground/service/SSO stay attached and
      the PID is captured via `pgrep` after a short delay (openconnect only writes
      `--pid-file` when daemonizing). `notify` + `run_hooks` fire on connect/disconnect.
@@ -137,7 +148,9 @@ waits, SIGKILL fallback, then cleans pid/state and fires the disconnected hook.
 `vpn-up start <profile>` with `VPN_UP_SERVICE=1` and supervises openconnect in the
 foreground (KeepAlive/Restart for auto-reconnect). `_service_preflight` refuses
 passcode and SSO profiles (interactive) and warns on missing passwordless sudo / stored
-password.
+password — but not about a missing password for a cert-only profile, and it flags a
+PKCS#11 cert without a stored PIN (or a possibly-encrypted file key) as unable to run
+unattended.
 
 ## 6. Security model (summary)
 
@@ -155,8 +168,9 @@ password.
 ## 7. Quality & CI
 
 - **Tests:** `bats` suite under [tests/](tests/) (`cli`, `core`, `lifecycle`, `logging`,
-  `network`, `profiles`, `secrets`, `service`, `sso`, `totp`, `extraargs`, `ui_setup`),
-  with stubs for network, sudo, keychain, oathtool, and service managers.
+  `network`, `profiles`, `secrets`, `service`, `sso`, `totp`, `extraargs`,
+  `clientcert`, `ui_setup`), with stubs for network, sudo, keychain, oathtool, and
+  service managers.
 - **CI** ([.github/workflows/ci.yml](.github/workflows/ci.yml)): shellcheck +
   `bats tests/` on **macOS and Ubuntu** + gitleaks + CodeQL on every push/PR. `main` is
   protected and PR-only.
@@ -183,5 +197,11 @@ password.
 - **`extraArgs` tokenized with `xargs`** — gives shell-like quote/escape handling for a
   free-form flag string **without `eval`** (no command substitution or globbing); collisions
   with managed flags warn rather than block.
+- **Client-cert PIN via `pin-source` file, never argv** — a PKCS#11 PIN would leak in the
+  process table if passed as `--key-password`, so (mirroring the TOTP decision) the PIN is
+  written to a transient `0600` file referenced by RFC 7512 `pin-source` and shredded after.
+  Trade-off: it depends on the local GnuTLS honoring `pin-source` (else openconnect prompts),
+  and a stored PIN is "1.5-factor"; a passphrase-protected *file* key has no non-argv feed at
+  all, so it is interactive-only — both documented.
 - **`PROGRAM_NAME` vs `DISPLAY_NAME`** — data-file/slug/Keychain namespace is decoupled
   from user-facing naming, so the public command reads `vpn-up` without disturbing state paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.9.0] — 2026-06-18
+### Client-certificate authentication
+
+### Added
+- **Client-certificate authentication** (`<clientCertificate>` / `<clientKey>`,
+  also prompted by `add-profile`). Authenticate with an X.509 cert/key **file** or
+  a **PKCS#11 URI** (smartcard / **YubiKey PIV**), on its own (cert-only) or
+  alongside a password, Duo, TOTP, or SSO — it's additive and doesn't change the
+  auth precedence. The cert/key **path or URI is not a secret** (it stays in the
+  profile); a key passphrase or PKCS#11 PIN **never reaches openconnect's argv**.
+  An encrypted key/token prompts interactively; for unattended/login-service use,
+  store a PKCS#11 PIN (`vpn-up set-secret '<profile>' key_password`) and `vpn-up`
+  feeds it through a transient `0600` `pin-source` file, shredded after the session.
+- `doctor` now reports **PKCS#11** (`p11-kit`/`p11tool`) availability; `service`
+  preflight understands cert-only and PKCS#11 profiles.
+
+### Documented
+- **FIDO2 / passkeys / YubiKey-WebAuthn already work with SSO** — because the
+  browser-based SAML/SSO login runs in your real browser, no extra configuration is
+  needed. New [client-certificate](https://sorinipate.github.io/vpn-up-for-openconnect/client-certificate-auth/)
+  docs page; SSO page notes the WebAuthn support.
+
+---
+
 ## [v3.8.0] — 2026-06-18
 ### TOTP 2FA & Argument Passthrough Update
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
 # Product Requirements Document — VPN Up for OpenConnect
 
-**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-18 (v3.8.0)
+**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-18 (v3.9.0)
 
 > This PRD describes *what* VPN Up is and *why*. For *how* it's built, see
 > [ARCHITECTURE.md](ARCHITECTURE.md). For the change history, see
@@ -14,8 +14,9 @@
 on top of [OpenConnect](https://www.infradead.org/openconnect/). It lets macOS and
 Linux users connect to Cisco AnyConnect, Palo Alto GlobalProtect, Pulse Secure,
 Juniper Network Connect, and ocserv gateways from the terminal — with named
-profiles, Duo 2FA, TOTP authenticator codes, browser-based SSO, certificate
-pinning, secure secret storage, auto-reconnect, and shell completion.
+profiles, Duo 2FA, TOTP authenticator codes, browser-based SSO, client-certificate
+auth (incl. PKCS#11 smartcards / YubiKey PIV), certificate pinning, secure secret
+storage, auto-reconnect, and shell completion.
 
 It is a *wrapper*, not a fork: OpenConnect does the tunnelling; VPN Up provides the
 profile management, credential hygiene, and lifecycle ergonomics that raw
@@ -96,13 +97,22 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
   (prompted at connect time, never read from XML).
 - **FR-4** Support **browser-based SAML/SSO** (`authMode=sso`) via OpenConnect's
   `--external-browser` (openconnect ≥ 9.0; `anyconnect`/`gp` only). No password is
-  piped; the flow runs foreground with the controlling TTY.
+  piped; the flow runs foreground with the controlling TTY. Because the login
+  happens in the user's real browser, **FIDO2/passkey/YubiKey-WebAuthn** factors
+  the identity provider offers work with no extra configuration.
 - **FR-5** Background or foreground operation, configurable; SSO and service mode force foreground.
 - **FR-20** Support **TOTP authenticator-app 2FA** (`tokenMode=totp`): generate the
   current code from a seed held in the secrets backend (via `oathtool`) and feed it
   as the gateway's 2FA answer. The seed never reaches openconnect's argv or disk
   (no `--token-secret`); being non-interactive, a TOTP profile can run as an
   auto-reconnecting login service.
+- **FR-22** Support **client-certificate authentication** (`clientCertificate`,
+  `clientKey`): an X.509 cert/key **file** or a **PKCS#11 URI** (smartcard /
+  YubiKey PIV), applied additively alongside any auth mode (or cert-only). The
+  cert/key path or URI is not a secret (it lives in the profile); a key passphrase
+  or PKCS#11 PIN is a secret and never reaches argv — it is prompted interactively,
+  or, for a PKCS#11 token, fed from the secrets backend (`key_password`) via a
+  transient `pin-source` file so the profile can run as a login service.
 
 ### 6.2 Credentials & identity
 - **FR-6** Store secrets in the macOS Keychain, Linux Secret Service, or an
@@ -139,7 +149,8 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
   dirs `700`; no `eval`. See [SECURITY.md](SECURITY.md).
 - **NFR-2 Portability** — macOS + Linux; Bash ≥ 4; GNU/BSD differences handled
   (`stat`, `ps`, `sed`). No hard dependency beyond `openconnect`, `xmlstarlet`, and a
-  secret backend; `oathtool` is an optional dependency, needed only for TOTP profiles.
+  secret backend; `oathtool` (TOTP) and `p11-kit`/`p11tool` (PKCS#11 client
+  certificates) are optional dependencies, needed only for those features.
 - **NFR-3 Isolation** — all user state under `~/.config/vpn-up` (override via
   `VPN_UP_HOME`/`XDG_CONFIG_HOME`); reinstalling/cleaning the program directory never touches it.
 - **NFR-4 Quality** — shellcheck-clean; bats test suite on macOS + Ubuntu in CI; secret scanning (gitleaks) + CodeQL.
@@ -161,11 +172,18 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 - On Linux, a root-spawned SSO browser may not reach the desktop session (mitigated by
   the `VPN_UP_EXTERNAL_BROWSER` override).
 - TOTP stores the seed beside the password in the same secret backend — effectively
-  "1.5-factor"; it's opt-in. RSA SecurID and Yubikey OATH tokens are not yet supported.
+  "1.5-factor"; it's opt-in. RSA SecurID and Yubikey OATH (HOTP) tokens are not yet
+  supported (a Yubikey PIV *client certificate* is — see FR-22).
+- A **passphrase-protected client-certificate file** cannot run as a login service
+  (no TTY to prompt on); use an unencrypted `0600` key or a PKCS#11 token with a
+  stored PIN. A stored PKCS#11 PIN sits in the same secret backend as the password
+  (same "1.5-factor" caveat). The `pin-source` feed depends on the local GnuTLS
+  honoring RFC 7512; otherwise OpenConnect falls back to prompting.
 
 ## 10. Roadmap (under consideration)
 
-- RSA SecurID / Yubikey OATH token support (TOTP already shipped in v3.8.0).
+- RSA SecurID / Yubikey OATH (HOTP) token support (TOTP shipped in v3.8.0; PKCS#11
+  client certificates, incl. Yubikey PIV, shipped in v3.9.0).
 - First-class HTTP/SOCKS proxy field (today a proxy can be passed via `extraArgs`).
 - Multiple simultaneous tunnels (per-profile state already lays the groundwork).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.8.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.9.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)
@@ -98,7 +98,8 @@ VPN Up is useful if you:
 - **Multiple VPN profiles** — pick from an interactive menu or connect by name with zero prompts (`vpn-up start "Work VPN"`), with full **AuthGroup/realm** support
 - **Duo 2FA** — `push`, `phone`, `sms`, or one-time passcodes prompted at connect time; empty method lets the gateway auto-push
 - **TOTP authenticator-app 2FA** — store the seed once and `vpn-up` generates the code at connect time (via `oathtool`); fully non-interactive, so it works as an auto-reconnecting login service
-- **SSO / external-browser login** — for gateways that force a browser-based SAML/SSO flow (Okta, Azure AD, Ping Identity, often with an embedded Duo iframe), via OpenConnect's `--external-browser` (needs openconnect ≥ 9.0)
+- **SSO / external-browser login** — for gateways that force a browser-based SAML/SSO flow (Okta, Azure AD, Ping Identity, often with an embedded Duo iframe), via OpenConnect's `--external-browser` (needs openconnect ≥ 9.0). Because the login runs in your **real** browser, **passkeys / FIDO2 / YubiKey-WebAuthn work automatically**
+- **Client-certificate authentication** — an X.509 cert/key file *or* a **PKCS#11** smartcard / **YubiKey PIV**, on its own or alongside a password/SSO; the key passphrase or PIN is kept out of the process table
 - **Background or foreground** execution, per your config
 
 ### Secure
@@ -117,7 +118,7 @@ VPN Up is useful if you:
 - **Guided setup** — a first-run wizard plus `add-profile` / `remove-profile`, which handle XML, secrets, pins, and services in one step
 - **`doctor`** diagnostics — environment, dependencies, secret backend, and config at a glance
 - **Bash/zsh tab completion** for commands and profile names
-- **Hardened & tested** — 71 tests on macOS + Ubuntu in CI, shellcheck-clean, secret scanning, modern Bash (≥ 4), no `eval`
+- **Hardened & tested** — 100+ tests on macOS + Ubuntu in CI, shellcheck-clean, secret scanning, modern Bash (≥ 4), no `eval`
 
 ---
 
@@ -377,6 +378,20 @@ Need an openconnect flag `vpn-up` doesn't model (`--no-dtls`, `--os=win`, `--csd
 - Avoid flags `vpn-up` already manages — `--protocol`, `--user`, `--passwd-on-stdin`, `--background`, `--servercert`, `--authgroup`, `--pid-file`, `--external-browser`, `--token-mode`/`--token-secret`. Duplicating one prints a warning (it may conflict) but is still passed.
 - ⚠️ openconnect runs as **root**; some flags execute programs as root (e.g. `--csd-wrapper`, `--script`). Only put flags here that you'd be comfortable running under `sudo` yourself.
 
+### Client-certificate authentication
+
+Authenticate with an **X.509 client certificate** — a file or a **PKCS#11** smartcard / **YubiKey PIV** — on its own (cert-only) or alongside a password/SSO. Set `<clientCertificate>` (and `<clientKey>` if the key is separate); each is a file path or a `pkcs11:` URI:
+
+```xml
+<clientCertificate>/etc/vpn/me.pem</clientCertificate>
+<!-- or a smartcard / YubiKey PIV: -->
+<clientCertificate>pkcs11:manufacturer=piv_II;id=%01;type=cert</clientCertificate>
+```
+
+- The cert **path/URI is not a secret** (it stays in the XML); a key **passphrase or PKCS#11 PIN is** — it never goes on the command line. An encrypted key/token prompts interactively, or store a PKCS#11 PIN for unattended use: `vpn-up set-secret "Work" key_password` (fed via a transient `pin-source` file, never argv).
+- For a [login service](#run-as-a-login-service-auto-reconnect), use a PKCS#11 token with a stored PIN, or an unencrypted `0600` key file (a passphrase-protected file key can't run unattended — there's no TTY to prompt on).
+- `vpn-up doctor` reports PKCS#11 (`p11-kit`) availability. Full guide: [docs/client-certificate-auth](https://sorinipate.github.io/vpn-up-for-openconnect/client-certificate-auth/).
+
 ---
 
 ## ⚙️ Configuration
@@ -413,11 +428,13 @@ Seeded from [config/vpn-up.command.profiles.default](config/vpn-up.command.profi
     <authMode>password</authMode>
     <tokenMode>totp</tokenMode>
     <extraArgs>--no-dtls</extraArgs>
+    <clientCertificate>/etc/vpn/me.pem</clientCertificate>
+    <clientKey></clientKey>
   </VPN>
 </VPNs>
 ```
 
-Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login). `<tokenMode>` is empty (default) or `totp` for [authenticator-app 2FA](#totp-authenticator-app-2fa). `<extraArgs>` passes extra openconnect flags verbatim — see [Advanced: extra openconnect arguments](#advanced-extra-openconnect-arguments).
+Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login). `<tokenMode>` is empty (default) or `totp` for [authenticator-app 2FA](#totp-authenticator-app-2fa). `<extraArgs>` passes extra openconnect flags verbatim — see [Advanced: extra openconnect arguments](#advanced-extra-openconnect-arguments). `<clientCertificate>`/`<clientKey>` enable [client-certificate authentication](#client-certificate-authentication) — a file path or a PKCS#11 URI; a key passphrase/PIN goes in the secrets backend (`key_password`), never the XML.
 
 ---
 
@@ -425,7 +442,7 @@ Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2
 
 **Under consideration** (open an issue if you need one of these):
 
-- RSA SecurID / Yubikey OATH token support (TOTP is already supported — see [TOTP authenticator-app 2FA](#totp-authenticator-app-2fa))
+- RSA SecurID / Yubikey OATH (HOTP) token support (TOTP authenticator codes are already supported — see [TOTP authenticator-app 2FA](#totp-authenticator-app-2fa) — as is a Yubikey **PIV client certificate** via [client-certificate authentication](#client-certificate-authentication))
 - HTTP/SOCKS proxy passthrough as a profile field
 - Multiple simultaneous tunnels (per-profile state files already lay the groundwork)
 

--- a/completions/vpn-up.bash
+++ b/completions/vpn-up.bash
@@ -41,7 +41,7 @@ _vpn_up() {
       if [ "$COMP_CWORD" -eq 2 ]; then
         _vpn_up_complete_profiles "$cur"
       elif [ "$COMP_CWORD" -eq 3 ]; then
-        mapfile -t COMPREPLY < <(compgen -W "password token_secret" -- "$cur")
+        mapfile -t COMPREPLY < <(compgen -W "password token_secret key_password" -- "$cur")
       fi
       ;;
     logs)

--- a/config/vpn-up.command.profiles.default
+++ b/config/vpn-up.command.profiles.default
@@ -35,6 +35,20 @@
              NOTE: openconnect runs as root — some flags (e.g. --csd-wrapper,
              --script) execute programs as root. -->
         <extraArgs></extraArgs>
+        <!-- clientCertificate / clientKey (optional): X.509 client-certificate
+             authentication. Each may be a file path or a PKCS#11 URI for a
+             smartcard / YubiKey PIV, e.g.
+               <clientCertificate>/etc/vpn/me.pem</clientCertificate>
+               <clientCertificate>pkcs11:manufacturer=piv_II;id=%01</clientCertificate>
+             clientKey is only needed when the private key is separate from the
+             cert. The cert/key path or URI is NOT a secret; a key passphrase or
+             PKCS#11 PIN is — store it in the secrets backend instead of here:
+             vpn-up set-secret "<profile name>" key_password
+             An encrypted key prompts for its passphrase interactively (foreground
+             only). For a login service, use an unencrypted 0600 key or a PKCS#11
+             token with a stored PIN. -->
+        <clientCertificate></clientCertificate>
+        <clientKey></clientKey>
     </VPN>
 
     <!-- VPN PROFILE 2 -->
@@ -62,6 +76,10 @@
              NOTE: openconnect runs as root — some flags (e.g. --csd-wrapper,
              --script) execute programs as root. -->
         <extraArgs></extraArgs>
+        <!-- clientCertificate / clientKey: see VPN PROFILE 1. A key passphrase or
+             PKCS#11 PIN goes in the secrets backend (key_password), not here. -->
+        <clientCertificate></clientCertificate>
+        <clientKey></clientKey>
     </VPN>
     <!-- Add more VPN profiles as needed -->
 </VPNs>

--- a/core.sh
+++ b/core.sh
@@ -382,6 +382,22 @@ generate_totp() {
   oathtool --totp -b "$1" 2>/dev/null
 }
 
+# Securely supply a PKCS#11 PIN (e.g. a YubiKey PIV smartcard) to openconnect
+# WITHOUT placing it on argv: reference a transient 0600 file via the RFC 7512
+# 'pin-source' URI attribute. Best-effort — if the local GnuTLS build ignores
+# pin-source, openconnect simply falls back to prompting on the TTY. Non-pkcs11
+# URIs (and plain file keys) are returned unchanged; those rely on openconnect's
+# interactive passphrase prompt, since it offers no non-argv feed for them.
+_append_pkcs11_pin_source() {
+  local uri="$1" pinfile="$2" sep='?'
+  case "$uri" in
+    pkcs11:*) ;;
+    *) printf '%s' "$uri"; return ;;
+  esac
+  case "$uri" in *\?*) sep='&' ;; esac
+  printf '%s%spin-source=file:%s' "$uri" "$sep" "$pinfile"
+}
+
 # Warn (but don't block) when a user-supplied extra arg duplicates a flag that
 # vpn-up already manages — overriding these can break connection or status/stop.
 _warn_extra_arg_collisions() {
@@ -389,7 +405,7 @@ _warn_extra_arg_collisions() {
   for tok in "$@"; do
     base="${tok%%=*}"
     case "$base" in
-      --protocol|-q|--user|--passwd-on-stdin|--background|--servercert|--authgroup|--pid-file|--external-browser|--token-mode|--token-secret)
+      --protocol|-q|--user|--passwd-on-stdin|--background|--servercert|--authgroup|--pid-file|--external-browser|--token-mode|--token-secret|--certificate|-c|--sslkey|-k|--key-password)
         print_warning "extraArgs contains '%s', which vpn-up already manages; passing it anyway (may conflict).\n" "$base" ;;
     esac
   done
@@ -431,6 +447,29 @@ run_openconnect() {
   [ "$effective_background" = TRUE ] && args+=(--background)
   [ -n "$SERVER_CERTIFICATE" ] && args+=(--servercert="$SERVER_CERTIFICATE")
   [ -n "$VPN_GROUP" ] && args+=(--authgroup "$VPN_GROUP")
+  # Client-certificate auth (X.509). The cert/key may be a file path or a PKCS#11
+  # URI (smartcard / YubiKey PIV) — an identifier, not a secret, so it is safe on
+  # argv. A key passphrase / PKCS#11 PIN is a secret and must NOT hit argv: for a
+  # pkcs11: URI with a stored 'key_password' we feed the PIN via a transient 0600
+  # file (pin-source); a file key's passphrase is prompted interactively.
+  local _pin_file="" _cc="${VPN_CLIENT_CERT:-}" _ck="${VPN_CLIENT_KEY:-}"
+  if [ -n "$_cc" ]; then
+    case "$_cc" in
+      pkcs11:*)
+        local _pin; _pin="$(secrets_get "${VPN_NAME}" key_password 2>/dev/null)"
+        if [ -n "$_pin" ]; then
+          _pin_file="${DATA_DIR}/pids/.${PROGRAM_NAME}.$(profile_slug "$VPN_NAME").pin"
+          ( umask 077; printf '%s' "$_pin" > "$_pin_file" )
+          chmod 600 "$_pin_file" 2>/dev/null || true
+          _cc="$(_append_pkcs11_pin_source "$_cc" "$_pin_file")"
+          [ -n "$_ck" ] && _ck="$(_append_pkcs11_pin_source "$_ck" "$_pin_file")"
+          unset _pin
+        fi
+        ;;
+    esac
+    args+=(--certificate="$_cc")
+    [ -n "$_ck" ] && args+=(--sslkey="$_ck")
+  fi
   # Extra user-supplied openconnect args (advanced). Tokenized with xargs so
   # quotes are respected without eval; appended verbatim before the host.
   if [ -n "${VPN_EXTRA_ARGS:-}" ]; then
@@ -505,6 +544,12 @@ run_openconnect() {
     rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
     notify "VPN Up" "Disconnected from ${VPN_NAME:-VPN}"
     run_hooks disconnected "${VPN_NAME:-}" "${VPN_HOST:-}"
+  fi
+
+  # Shred the transient PKCS#11 PIN file (openconnect has read it during auth).
+  if [ -n "${_pin_file:-}" ] && [ -e "$_pin_file" ]; then
+    if command -v shred >/dev/null 2>&1; then shred -u "$_pin_file" 2>/dev/null || rm -f "$_pin_file"
+    else rm -f "$_pin_file"; fi
   fi
 
   # Drop the password and any generated 2FA code from shell memory as soon as

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -86,6 +86,13 @@ doctor() {
   else
     echo "  [..] oathtool not found (needed only for TOTP 2FA: brew install oath-toolkit | apt-get install oathtool)"
   fi
+  # PKCS#11 (p11-kit / GnuTLS) lets openconnect use a client certificate from a
+  # smartcard / YubiKey PIV; file-based client certs need nothing extra.
+  if command -v p11tool >/dev/null 2>&1 || command -v p11-kit >/dev/null 2>&1; then
+    echo "  [OK] PKCS#11 tooling present (smartcard / YubiKey-PIV client certificates)"
+  else
+    echo "  [..] p11-kit/p11tool not found (needed only for PKCS#11 client certs: brew install p11-kit | apt-get install p11-kit; file-based client certs work without it)"
+  fi
   if [ "$(uname)" = "Darwin" ]; then
     if command -v security >/dev/null 2>&1; then echo "  [OK] security (Keychain)"; else echo "  [!!] security missing"; fi
   else

--- a/docs/client-certificate-auth.md
+++ b/docs/client-certificate-auth.md
@@ -1,0 +1,90 @@
+---
+layout: page
+title: Client-certificate VPN authentication (file or PKCS#11 / YubiKey PIV)
+description: >-
+  Authenticate to an OpenConnect VPN with an X.509 client certificate using VPN
+  Up — a PEM/key file or a PKCS#11 smartcard / YubiKey PIV — on macOS and Linux,
+  with the key passphrase / PIN kept out of the process table.
+permalink: /client-certificate-auth/
+---
+
+# Client-certificate authentication
+
+VPN Up can authenticate to a gateway with an **X.509 client certificate** —
+either a file on disk or a **PKCS#11** token such as a smartcard or **YubiKey
+PIV**. A client certificate is *additive*: it works on its own (cert-only) or
+alongside a password, Duo, TOTP, or browser SSO — it does not replace them.
+
+## Configure a profile
+
+Add `clientCertificate` (and, if the private key is separate, `clientKey`) to the
+profile. Each may be a **file path** or a **PKCS#11 URI**.
+
+```xml
+<VPN>
+  <name>Work (cert)</name>
+  <protocol>anyconnect</protocol>
+  <host>vpn.example.com</host>
+  <user>you</user>
+  <!-- A PEM file holding cert + key, or split across two files: -->
+  <clientCertificate>/etc/vpn/me.pem</clientCertificate>
+  <clientKey></clientKey>
+</VPN>
+```
+
+Or run the wizard: `vpn-up add-profile` prompts for the certificate (and, for a
+`pkcs11:` URI, offers to store the PIN). Then connect:
+
+```bash
+vpn-up start "Work (cert)"
+```
+
+## Smartcards & YubiKey PIV (PKCS#11)
+
+OpenConnect addresses smartcard certificates with a [PKCS#11
+URI](https://www.infradead.org/openconnect/pkcs11.html). List your token's
+objects with `p11tool --list-all` and use the URI as the certificate:
+
+```xml
+<clientCertificate>pkcs11:manufacturer=piv_II;id=%01;type=cert</clientCertificate>
+```
+
+`vpn-up doctor` reports whether PKCS#11 tooling (`p11-kit`/`p11tool`) is present.
+
+## Where the passphrase / PIN goes
+
+The certificate **path or URI is not a secret**, so it lives in the profile XML.
+A **key passphrase or PKCS#11 PIN is** a secret and never goes on the command
+line (it would otherwise be visible in the process table):
+
+- **Interactive (default, most secure):** if the key/token needs a passphrase or
+  PIN, OpenConnect prompts for it on the terminal. Nothing is stored.
+- **Stored, for a login service:** store the PKCS#11 PIN in the secrets backend so
+  the connection can run unattended —
+
+  ```bash
+  vpn-up set-secret "Work (cert)" key_password
+  ```
+
+  VPN Up feeds it to OpenConnect through a transient `0600` file
+  (`pin-source`), never on the command line, and removes the file after the
+  session.
+
+## Running as a login service
+
+A cert profile can [auto-connect at login]({{ '/vpn-at-login/' | relative_url }})
+only when it needs no interactive prompt:
+
+- **PKCS#11 token:** store the PIN (`key_password`) first.
+- **File-based key:** use an **unencrypted key** with `0600` permissions (the file
+  permissions protect it). A passphrase-protected file key cannot run as a service
+  because there is no terminal to prompt on.
+
+`vpn-up service install "Work (cert)"` warns if the profile would need a prompt.
+
+## Related
+
+- [SSO & 2FA]({{ '/sso-duo/' | relative_url }}) — browser SSO (passkeys / YubiKey
+  WebAuthn work here too), Duo, and TOTP.
+- [Supported protocols]({{ '/protocols/' | relative_url }}) ·
+  [Auto-connect at login]({{ '/vpn-at-login/' | relative_url }}).

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ See the [installation guide]({{ '/installation/' | relative_url }}) for manual s
 - [Cisco AnyConnect command-line alternative]({{ '/anyconnect-cli-alternative/' | relative_url }}) — connect to AnyConnect VPNs without the GUI client
 - [Connect to GlobalProtect from the command line]({{ '/globalprotect-cli/' | relative_url }}) — Palo Alto GlobalProtect via OpenConnect
 - [Auto-connect a VPN at login]({{ '/vpn-at-login/' | relative_url }}) — launchd (macOS) & systemd (Linux) with auto-reconnect
+- [Client-certificate authentication]({{ '/client-certificate-auth/' | relative_url }}) — X.509 file or PKCS#11 smartcard / YubiKey PIV
 - [VPN Up vs. raw OpenConnect]({{ '/vs-openconnect/' | relative_url }}) — what the wrapper adds, and when to use each
 - [VPN Up vs. openconnect-sso]({{ '/vs-openconnect-sso/' | relative_url }}) — two AnyConnect SSO clients compared, fairly
 - [VPN Up vs. GlobalProtect-openconnect]({{ '/vs-globalprotect-openconnect/' | relative_url }}) — two GlobalProtect CLI clients compared

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -52,3 +52,6 @@ If the vendor client is "Cisco AnyConnect," use `anyconnect`. For Palo Alto
 GlobalProtect use `gp`. When in doubt, try `anyconnect` first — many gateways are
 AnyConnect-compatible. See [troubleshooting]({{ '/troubleshooting/' | relative_url }})
 if a connection fails.
+
+Authenticating with a certificate instead of (or in addition to) a password? See
+[client-certificate authentication]({{ '/client-certificate-auth/' | relative_url }}).

--- a/docs/sso-duo.md
+++ b/docs/sso-duo.md
@@ -75,6 +75,14 @@ VPN Up runs OpenConnect with `--external-browser`: it opens your browser to the
 identity provider, you complete the login (including Duo) there, and the tunnel
 comes up afterward. **No password is stored or piped** for SSO profiles.
 
+> **Passkeys & FIDO2 / YubiKey (WebAuthn) work automatically.** Because the SSO
+> login happens in your **real** browser, any authenticator the identity provider
+> accepts — a passkey, a FIDO2 security key, or a YubiKey as a WebAuthn device —
+> just works, with no extra configuration in VPN Up. (Delegating to the real
+> browser, rather than an embedded one, is what makes hardware WebAuthn reliable.)
+> For a YubiKey holding a *client certificate* (PIV) instead, see
+> [client-certificate authentication]({{ '/client-certificate-auth/' | relative_url }}).
+
 ### Requirements and behavior
 
 - **OpenConnect ≥ 9.0** (when `--external-browser` landed). `vpn-up doctor` reports

--- a/profiles.sh
+++ b/profiles.sh
@@ -34,7 +34,9 @@ load_profile_fields() {
       -v "serverCertificate" -n \
       -v "authMode | authmode" -n \
       -v "tokenMode | tokenmode" -n \
-      -v "extraArgs | extraargs" -n "${PROFILES_FILE}"
+      -v "extraArgs | extraargs" -n \
+      -v "clientCertificate | clientcertificate" -n \
+      -v "clientKey | clientkey" -n "${PROFILES_FILE}"
   )
   VPN_NAME="${fields[0]:-}"
   PROTOCOL="${fields[1]:-}"
@@ -51,6 +53,11 @@ load_profile_fields() {
   VPN_TOKEN_MODE="$(printf '%s' "${fields[9]:-}" | tr '[:upper:]' '[:lower:]')"
   # Advanced: extra openconnect arguments passed verbatim (tokenized at connect).
   VPN_EXTRA_ARGS="${fields[10]:-}"
+  # Client-certificate auth: a file path or a PKCS#11 URI (pkcs11:...) for a
+  # smartcard/YubiKey-PIV. The optional key may be a separate file/URI. These are
+  # identifiers, not secrets; any passphrase/PIN lives in the secrets backend.
+  VPN_CLIENT_CERT="${fields[11]:-}"
+  VPN_CLIENT_KEY="${fields[12]:-}"
 
   # Intentionally NOT exported: these are read only by functions in this
   # shell, and exporting would copy the password into the environment of
@@ -81,6 +88,13 @@ migrate_or_fetch_password() {
     secrets_set "${VPN_NAME}" "password" "${VPN_PASSWD}"
     s="${VPN_PASSWD}"
     scrub_profile_password "${VPN_NAME}"
+  fi
+  if [ -z "$s" ] && [ -n "${VPN_CLIENT_CERT:-}" ]; then
+    # Cert-only auth: the client certificate stands in for the password. Don't
+    # force a prompt or fail; a password is used only if one is actually stored
+    # (cert + password gateways).
+    VPN_PASSWD=""
+    return 0
   fi
   if [ -z "$s" ]; then
     if [ -n "${VPN_UP_SERVICE:-}" ]; then

--- a/service.sh
+++ b/service.sh
@@ -105,7 +105,11 @@ _service_preflight() {
   if ! sudo -n -v 2>/dev/null; then
     print_warning "No passwordless sudo detected. Service mode requires a sudoers rule for openconnect (see README); the service will fail until it exists.\n"
   fi
-  if [ -z "$(secrets_get "$profile" "password" 2>/dev/null)" ]; then
+  local clientcert
+  clientcert="$(xmlstarlet sel -t -m "//VPN[name=$(xpath_literal "$profile")]" -v 'clientCertificate | clientcertificate' "$PROFILES_FILE" 2>/dev/null)"
+  # A cert-only profile needs no stored password, so only warn about a missing
+  # password when there is no client certificate to authenticate with.
+  if [ -z "$clientcert" ] && [ -z "$(secrets_get "$profile" "password" 2>/dev/null)" ]; then
     print_warning "No stored password for '%s'. Store one first: %s set-secret '%s' password\n" "$profile" "${DISPLAY_NAME}" "$profile"
   fi
   local duo
@@ -124,6 +128,21 @@ _service_preflight() {
       return 1
     fi
     command -v oathtool >/dev/null 2>&1 || print_warning "'oathtool' not found; the TOTP service will fail until it's installed (brew install oath-toolkit | apt-get install oathtool).\n"
+  fi
+  # Client-certificate auth works as a service only when no interactive prompt is
+  # needed. A PKCS#11 token needs a stored PIN (key_password); a file-based key
+  # must be unencrypted (a passphrase prompt has no TTY under launchd/systemd).
+  if [ -n "$clientcert" ]; then
+    case "$clientcert" in
+      pkcs11:*)
+        if [ -z "$(secrets_get "$profile" "key_password" 2>/dev/null)" ]; then
+          print_warning "Profile '%s' uses a PKCS#11 client certificate; a service can't enter the PIN. Store it first: %s set-secret '%s' key_password\n" "$profile" "${DISPLAY_NAME}" "$profile"
+        fi
+        ;;
+      *)
+        print_warning "Profile '%s' uses a client-certificate file. If the private key is passphrase-protected it cannot run as a service (no TTY to prompt); use an unencrypted 0600 key.\n" "$profile"
+        ;;
+    esac
   fi
   return 0
 }

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ CFG
 # Append a <VPN> block to the profiles file (password stays empty — secrets
 # belong in the secrets backend, set separately).
 append_profile() {
-  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}" extraargs="${9:-}"
+  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}" extraargs="${9:-}" clientcert="${10:-}" clientkey="${11:-}"
   local tmp="${PROFILES_FILE}.tmp"
   xmlstarlet ed \
     -s '/VPNs' -t elem -n VPN -v '' \
@@ -75,6 +75,8 @@ append_profile() {
     -s '/VPNs/VPN[last()]' -t elem -n authMode -v "$authmode" \
     -s '/VPNs/VPN[last()]' -t elem -n tokenMode -v "$tokenmode" \
     -s '/VPNs/VPN[last()]' -t elem -n extraArgs -v "$extraargs" \
+    -s '/VPNs/VPN[last()]' -t elem -n clientCertificate -v "$clientcert" \
+    -s '/VPNs/VPN[last()]' -t elem -n clientKey -v "$clientkey" \
     "${PROFILES_FILE}" > "${tmp}" && mv "${tmp}" "${PROFILES_FILE}" && chmod 600 "${PROFILES_FILE}"
 }
 
@@ -83,7 +85,7 @@ add_profile_wizard() {
     ( umask 077; printf '<VPNs>\n</VPNs>\n' > "$PROFILES_FILE" )
   fi
 
-  local name proto host group user duo authmode tokenmode extraargs
+  local name proto host group user duo authmode tokenmode extraargs clientcert clientkey
   read -r -p "Profile name: " name
   [ -n "$name" ] || { print_danger "Profile name is required.\n"; return 1; }
   if profile_exists "$name"; then
@@ -138,17 +140,43 @@ add_profile_wizard() {
     esac
   fi
 
+  # Client-certificate auth (optional): a file path or a PKCS#11 URI (smartcard /
+  # YubiKey PIV). Additive — it works alongside any auth mode, including SSO.
+  clientcert=""; clientkey=""
+  read -r -p "Client certificate (file path or pkcs11: URI, optional): " clientcert
+  if [ -n "$clientcert" ]; then
+    read -r -p "Client key (file path or pkcs11: URI; empty if in the cert): " clientkey
+    case "$clientcert" in
+      pkcs11:*)
+        local _in_pin=""
+        read -r -p "Store the PKCS#11 PIN now (needed for a login service)? [y/N]: " _in_pin
+        if [ "$(_bool_default "${_in_pin}" "FALSE")" = TRUE ]; then
+          local _pin
+          read -r -s -p "Enter the PKCS#11 PIN: " _pin; echo
+          [ -n "$_pin" ] && secrets_set "$name" "key_password" "$_pin" && print_success "PKCS#11 PIN stored securely.\n"
+          unset _pin
+        fi
+        ;;
+      *)
+        print_warning "If the key is passphrase-protected, openconnect will prompt for it at connect time (foreground only).\n" ;;
+    esac
+  fi
+
   # Advanced (optional): extra openconnect flags passed verbatim at connect time.
   extraargs=""
   read -r -p "Extra openconnect arguments (advanced, optional): " extraargs
 
-  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" "$extraargs" \
+  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" "$extraargs" "$clientcert" "$clientkey" \
     || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
   print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
 
   if [ "$authmode" != sso ]; then
-    read -r -p "Store the VPN password now? [Y/n]: " _in_pw
-    if [ "$(_bool_default "${_in_pw}" "TRUE")" = TRUE ]; then
+    # Cert-only gateways need no password, so default to "no" when a client
+    # certificate is configured; otherwise default to "yes".
+    local _pw_default="TRUE" _pw_hint="[Y/n]"
+    if [ -n "$clientcert" ]; then _pw_default="FALSE"; _pw_hint="[y/N]"; fi
+    read -r -p "Store the VPN password now? ${_pw_hint}: " _in_pw
+    if [ "$(_bool_default "${_in_pw}" "${_pw_default}")" = TRUE ]; then
       local _p
       read -r -s -p "Enter password for ${user}@${host}: " _p; echo
       [ -n "$_p" ] && secrets_set "$name" "password" "$_p" && print_success "Password stored securely.\n"

--- a/tests/clientcert.bats
+++ b/tests/clientcert.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for client-certificate authentication (clientCertificate / clientKey),
+# including the PKCS#11 (smartcard / YubiKey-PIV) PIN path. The security-critical
+# invariant: the cert/key path or URI may appear on argv, but a key passphrase /
+# PKCS#11 PIN must NEVER reach argv.
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { printf -- "$1" "${@:2}"; }
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_success() { printf -- "$1" "${@:2}"; }
+  print_primary() { printf -- "$1" "${@:2}"; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../dependencies.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+_write_profiles() {
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>Cert VPN</name><protocol>anyconnect</protocol><host>c.example.com</host><authGroup></authGroup><user>alice</user><password></password><duo2FAMethod></duo2FAMethod><serverCertificate></serverCertificate><authMode>password</authMode><tokenMode></tokenMode><extraArgs></extraArgs><clientCertificate>/etc/vpn/me.pem</clientCertificate><clientKey>/etc/vpn/me.key</clientKey></VPN>
+  <VPN><name>PKCS VPN</name><protocol>anyconnect</protocol><host>p.example.com</host><authGroup></authGroup><user>bob</user><password></password><duo2FAMethod></duo2FAMethod><serverCertificate></serverCertificate><authMode>password</authMode><tokenMode></tokenMode><extraArgs></extraArgs><clientCertificate>pkcs11:manufacturer=piv_II;id=%01</clientCertificate></VPN>
+  <VPN><name>Plain VPN</name><protocol>anyconnect</protocol><host>x.example.com</host><authGroup></authGroup><user>carol</user><password></password><duo2FAMethod>push</duo2FAMethod></VPN>
+</VPNs>
+XML
+}
+
+# --- schema ---
+
+@test "load_profile_fields reads clientCertificate/clientKey and leaves earlier fields intact" {
+  _write_profiles
+  load_profile_fields "Cert VPN"
+  [ "$VPN_NAME" = "Cert VPN" ]
+  [ "$VPN_USER" = "alice" ]
+  [ "$VPN_AUTH_MODE" = "password" ]
+  [ "$VPN_CLIENT_CERT" = "/etc/vpn/me.pem" ]
+  [ "$VPN_CLIENT_KEY" = "/etc/vpn/me.key" ]
+}
+
+@test "load_profile_fields leaves cert fields empty when the tags are absent" {
+  _write_profiles
+  load_profile_fields "Plain VPN"
+  [ -z "$VPN_CLIENT_CERT" ]
+  [ -z "$VPN_CLIENT_KEY" ]
+  [ "$VPN_DUO2FAMETHOD" = "push" ]
+}
+
+# --- cert-only auth: no password is required or prompted ---
+
+@test "migrate_or_fetch_password does not require/prompt a password for a cert-only profile" {
+  _write_profiles
+  secrets_get() { echo ""; }            # nothing stored
+  load_profile_fields "Cert VPN"        # has a client cert, no password
+  run migrate_or_fetch_password
+  [ "$status" -eq 0 ]
+}
+
+# --- argv: cert/key flags present; path is fine on argv ---
+
+@test "run_openconnect passes --certificate/--sslkey for a file-based client cert" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv"
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$argv"; cat >/dev/null; return 0; fi; return 0; }
+  load_profile_fields "Cert VPN"
+  VPN_PASSWD=""
+  SERVER_CERTIFICATE="pin-sha256:abc"   # skip trust-store lookup
+  QUIET=FALSE; BACKGROUND=TRUE          # background branch (no tee/sleep)
+
+  connect
+
+  grep -qF -- "--certificate=/etc/vpn/me.pem" "$argv"
+  grep -qF -- "--sslkey=/etc/vpn/me.key" "$argv"
+}
+
+# --- the security-critical path: PKCS#11 PIN via pin-source file, NEVER on argv ---
+
+@test "run_openconnect feeds a PKCS#11 PIN via a 0600 pin-source file and never on argv" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv"
+  local PIN="918273"
+  secrets_get() { [ "$2" = key_password ] && echo "$PIN"; }   # stored PKCS#11 PIN
+  sudo() {
+    if [ "$1" = openconnect ]; then
+      shift; printf '%s\n' "$@" > "$argv"
+      local a p
+      for a in "$@"; do
+        case "$a" in
+          --certificate=pkcs11:*pin-source=file:*)
+            p="${a#*pin-source=file:}"
+            ls -l "$p" | cut -c1-10 > "$BATS_TEST_TMPDIR/pinperms"
+            cat "$p" > "$BATS_TEST_TMPDIR/pincontents"
+            ;;
+        esac
+      done
+      cat >/dev/null
+      return 0
+    fi
+    return 0
+  }
+  load_profile_fields "PKCS VPN"
+  VPN_PASSWD=""
+  SERVER_CERTIFICATE="pin-sha256:abc"
+  QUIET=FALSE; BACKGROUND=TRUE
+
+  connect
+
+  # argv references the PIN file, but never the PIN value itself
+  grep -qF -- "pin-source=file:" "$argv"
+  grep -qF -- "pkcs11:manufacturer=piv_II;id=%01" "$argv"
+  ! grep -qF -- "$PIN" "$argv"
+  # the PIN actually lived in a 0600 file (read back inside the stub)
+  [ "$(cat "$BATS_TEST_TMPDIR/pincontents")" = "$PIN" ]
+  [[ "$(cat "$BATS_TEST_TMPDIR/pinperms")" == -rw------* ]]
+  # and the transient file is shredded after the session
+  [ ! -e "${DATA_DIR}/pids/.${PROGRAM_NAME}.$(profile_slug "PKCS VPN").pin" ]
+}
+
+@test "run_openconnect omits pin-source when no PKCS#11 PIN is stored (interactive prompt)" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv"
+  secrets_get() { echo ""; }            # no stored PIN
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$argv"; cat >/dev/null; return 0; fi; return 0; }
+  load_profile_fields "PKCS VPN"
+  VPN_PASSWD=""
+  SERVER_CERTIFICATE="pin-sha256:abc"
+  QUIET=FALSE; BACKGROUND=TRUE
+
+  connect
+
+  grep -qF -- "--certificate=pkcs11:manufacturer=piv_II;id=%01" "$argv"
+  ! grep -qF -- "pin-source=file:" "$argv"
+}
+
+# --- collision warning includes the cert flags ---
+
+@test "_warn_extra_arg_collisions warns when extraArgs duplicates a cert flag" {
+  run _warn_extra_arg_collisions "--certificate=/tmp/x.pem"
+  [[ "$output" == *"--certificate"* ]]
+}
+
+# --- service mode ---
+
+@test "service preflight: cert-only profile does not warn about a missing password" {
+  _write_profiles
+  source "$BATS_TEST_DIRNAME/../service.sh"
+  sudo() { return 0; }
+  secrets_get() { echo ""; }
+  run _service_preflight "Cert VPN"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"No stored password"* ]]
+}
+
+@test "service preflight: PKCS#11 cert without a stored PIN warns to store key_password" {
+  _write_profiles
+  source "$BATS_TEST_DIRNAME/../service.sh"
+  sudo() { return 0; }
+  secrets_get() { echo ""; }            # no stored PIN
+  run _service_preflight "PKCS VPN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"key_password"* ]]
+}


### PR DESCRIPTION
## Summary

Adds first-class **client-certificate authentication** — the one genuine gap from the GlobalProtect-openconnect "flexible auth" comparison. (SSO, Duo, and TOTP already shipped; **FIDO2/YubiKey-WebAuthn already works via the real-browser SSO flow** and is now documented rather than re-built.)

New `<clientCertificate>` / `<clientKey>` profile fields accept an X.509 cert/key **file** or a **PKCS#11 URI** (smartcard / **YubiKey PIV**). A client cert is **additive** — cert-only or alongside password/Duo/TOTP/SSO — so it doesn't change the auth precedence.

### Security model (the crux)
- Cert/key **path or URI is not a secret** → safe on argv (`--certificate`/`--sslkey`).
- A key passphrase / PKCS#11 **PIN is a secret** → **never on argv**:
  - encrypted key/token → openconnect prompts interactively;
  - PKCS#11 PIN stored in the secrets backend (`key_password`) → fed via a transient `0600` `pin-source` file (RFC 7512), shredded after the session, so the profile can run as a login service.

## Changes
- **profiles.sh** — parse `clientCertificate`/`clientKey` (idx 11/12); cert-only profiles skip the password prompt.
- **core.sh** — argv wiring, `_append_pkcs11_pin_source`, PIN-file cleanup, cert flags in the collision watch list.
- **setup.sh / completions** — wizard prompts (incl. PKCS#11 PIN); `key_password` completion.
- **service.sh** — preflight allows non-interactive cert profiles, flags interactive ones.
- **dependencies.sh** — `doctor` reports PKCS#11 (`p11-kit`).
- **tests/clientcert.bats** — 9 tests; asserts the **PIN never appears on argv** and the pin-source file is `0600` and shredded.
- **Docs** — new `/client-certificate-auth/` page; SSO page documents FIDO2/passkey support; README/PRD/ARCHITECTURE/CHANGELOG → **v3.9.0**.

## Verification
- `bats tests/` → **103 pass** (macOS local; CI runs macOS + Ubuntu).
- `shellcheck --shell=bash --external-sources vpn-up.command *.sh` → clean.