### PR TITLE
Fix unparseable default profiles template (`--` in XML comments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.9.1] — 2026-06-18
+### Fixed
+
+- The default profiles template (`config/vpn-up.command.profiles.default`) could not
+  be parsed by `xmlstarlet`: its `<extraArgs>` comments contained `--` (e.g.
+  `--no-dtls`, `--protocol`), which the XML spec forbids inside comments and modern
+  libxml2 rejects as a fatal error. Users who **edit the seeded template by hand**
+  (rather than using `add-profile`, which generates comment-free XML) hit
+  `Double hyphen within comment` errors and an empty list from `vpn-up list` and the
+  interactive `start` menu, and silent "no profiles" detection. Reworded the comments
+  to be `--`-free; added a regression test that parses the shipped template.
+
+---
+
 ## [v3.9.0] — 2026-06-18
 ### Client-certificate authentication
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.9.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.9.1-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)

--- a/config/vpn-up.command.profiles.default
+++ b/config/vpn-up.command.profiles.default
@@ -28,12 +28,14 @@
              The TOTP secret is stored in the secrets backend, not here:
              vpn-up set-secret "<profile name>" token_secret  (needs oathtool). -->
         <tokenMode></tokenMode>
-        <!-- extraArgs (advanced): extra openconnect flags passed verbatim, e.g.
-             --no-dtls, --os=win, --csd-wrapper=/path. Quotes are respected.
-             Avoid flags vpn-up already manages (--protocol, --user, --pid-file,
-             --passwd-on-stdin, --background, --servercert, --authgroup, …).
-             NOTE: openconnect runs as root — some flags (e.g. --csd-wrapper,
-             --script) execute programs as root. -->
+        <!-- extraArgs (advanced): extra openconnect flags passed verbatim at
+             connect time, such as no-dtls, os=win, csd-wrapper, or a split-tunnel
+             script (write each with its usual leading dashes). Quotes are
+             respected. Avoid flags vpn-up already manages (protocol, user,
+             pid-file, passwd-on-stdin, background, servercert, authgroup,
+             external-browser, certificate, sslkey). openconnect runs as root, so
+             some flags (csd-wrapper, script) execute programs as root. Full list
+             and examples: https://sorinipate.github.io/vpn-up-for-openconnect/usage/ -->
         <extraArgs></extraArgs>
         <!-- clientCertificate / clientKey (optional): X.509 client-certificate
              authentication. Each may be a file path or a PKCS#11 URI for a
@@ -69,12 +71,7 @@
              The TOTP secret is stored in the secrets backend, not here:
              vpn-up set-secret "<profile name>" token_secret  (needs oathtool). -->
         <tokenMode></tokenMode>
-        <!-- extraArgs (advanced): extra openconnect flags passed verbatim, e.g.
-             --no-dtls, --os=win, --csd-wrapper=/path. Quotes are respected.
-             Avoid flags vpn-up already manages (--protocol, --user, --pid-file,
-             --passwd-on-stdin, --background, --servercert, --authgroup, …).
-             NOTE: openconnect runs as root — some flags (e.g. --csd-wrapper,
-             --script) execute programs as root. -->
+        <!-- extraArgs (advanced): see VPN PROFILE 1. -->
         <extraArgs></extraArgs>
         <!-- clientCertificate / clientKey: see VPN PROFILE 1. A key passphrase or
              PKCS#11 PIN goes in the secrets backend (key_password), not here. -->

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -124,3 +124,15 @@ XML
   VPN_DUO2FAMETHOD=weird;   set_2fa_method_description; [ "$VPN_DUO2FAMETHOD_DESCRIPTION" = "CUSTOM" ]
   VPN_DUO2FAMETHOD="";      set_2fa_method_description; [ "$VPN_DUO2FAMETHOD_DESCRIPTION" = "NONE" ]
 }
+
+# The shipped default template must be valid XML that xmlstarlet can parse. XML
+# forbids '--' inside comments; if a flag example like '--no-dtls' creeps back into
+# a comment, the file becomes unparseable and `list` / the start menu break for
+# users who edit the seeded template by hand. Parse the REAL default file here.
+@test "default profiles template parses cleanly and yields its placeholder names" {
+  local default_file="$BATS_TEST_DIRNAME/../config/vpn-up.command.profiles.default"
+  run xmlstarlet sel -t -m '//VPN' -v name -n "$default_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VPN PROFILE 1"* ]]
+  [[ "$output" == *"VPN PROFILE 2"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes a real (if conditional) first-run bug: the shipped default template `config/vpn-up.command.profiles.default` had `<extraArgs>` comments containing `--` (e.g. `--no-dtls`, `--protocol`, `--script`). XML forbids `--` inside `<!-- … -->`, and modern libxml2 (used by `xmlstarlet`) treats it as a **fatal parse error**.

A user who **edits the seeded template by hand** (comments left intact) ended up with a profiles file `xmlstarlet` couldn't parse:
- `vpn-up list` and the interactive `start` menu printed raw `Double hyphen within comment` errors with an empty list (stderr isn't suppressed there);
- `profile_names_raw` / `profile_exists` / service preflight silently returned "no profiles".

`add-profile` was unaffected (it builds comment-free XML via `xmlstarlet ed`), which is why this went unnoticed — and no test parsed the real `.default` file.

## Changes
- **config/vpn-up.command.profiles.default** — reword both `<extraArgs>` comment blocks to be `--`-free (name flags without leading dashes; defer the full list to the usage docs; collapse PROFILE 2's duplicate to a pointer). No `<…>` element changes.
- **tests/profiles.bats** — new regression test parses the **real shipped template** and asserts it yields `VPN PROFILE 1` / `VPN PROFILE 2` (fails before this fix; guards against reintroducing `--`).
- **CHANGELOG.md / README badge** — v3.9.1.

## Verification
- `xmlstarlet sel -t -m '//VPN' -v name -n config/vpn-up.command.profiles.default` → exits 0, prints both names, no stderr; `xmlstarlet val` → valid.
- `bats tests/` → **104 pass** (macOS local; CI runs macOS + Ubuntu); shellcheck clean.