### PR TITLE
Fail gracefully on a malformed profiles file (no leaked libxml2 errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.9.2] — 2026-06-18
+### Changed
+
+- Commands that read the profiles file (`list`, the interactive `start` menu,
+  `add-profile`, `remove-profile`, `pin --save`, `service install`) now **fail
+  gracefully on a malformed profiles file** with a single clear message ("Your
+  profiles file isn't valid XML …") instead of leaking raw `xmlstarlet`/libxml2
+  parser errors. A malformed file is also no longer silently misread as "no
+  profiles" (which previously could wrongly trigger the first-run wizard). New
+  internal `profiles_xml_ok` guard, with tests.
+
+---
+
 ## [v3.9.1] — 2026-06-18
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.9.1-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.9.2-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)

--- a/core.sh
+++ b/core.sh
@@ -60,6 +60,13 @@ start() {
   load_config
   print_warning "Loaded configuration from %s ...\n" "$CONFIGURATION_FILE"
 
+  # A malformed profiles file must fail with a clear message — not be silently
+  # misread as "no profiles" (which would wrongly trigger first-run) or leak raw
+  # libxml2 parser errors when we read it below.
+  if [ -f "$PROFILES_FILE" ] && ! profiles_xml_ok; then
+    exit 1
+  fi
+
   # First run with no profiles: offer the guided wizard when interactive;
   # fall back to seeding the XML template for scripts/services.
   if [ ! -f "$PROFILES_FILE" ] || [ -z "$(profile_names_raw)" ]; then

--- a/network.sh
+++ b/network.sh
@@ -30,6 +30,7 @@ verify_gateway_cert() {
 pin_save() {
   local profile="$1"
   check_file_existence "$PROFILES_FILE" "Profiles"
+  profiles_xml_ok || return 1
   if ! profile_exists "$profile"; then
     print_danger "Unknown profile '%s'.\n" "$profile"
     return 1

--- a/profiles.sh
+++ b/profiles.sh
@@ -12,6 +12,21 @@ xpath_literal() {
   printf "concat('%s')" "${s//\'/${rep}}"
 }
 
+# Verify the profiles file is well-formed XML. A missing file is treated as OK
+# (first-run handling and check_file_existence deal with absence separately). On
+# malformed XML, print ONE clear message — never the raw libxml2 parser noise —
+# and return 1, so callers can bail gracefully instead of leaking errors or
+# misreading the file as "no profiles". Reused by every command that reads it.
+profiles_xml_ok() {
+  [ -f "$PROFILES_FILE" ] || return 0
+  if ! xmlstarlet val "$PROFILES_FILE" >/dev/null 2>&1; then
+    print_danger "Your profiles file isn't valid XML, so it can't be read: %s\n" "$PROFILES_FILE"
+    print_warning "Edit it to fix the XML (a common cause is an XML comment containing a double hyphen), or recreate a profile with '%s add-profile'.\n" "${DISPLAY_NAME}"
+    return 1
+  fi
+  return 0
+}
+
 # shellcheck disable=SC2034  # fields are consumed by core.sh
 load_profile_fields() {
   local selection="$1"
@@ -108,7 +123,8 @@ migrate_or_fetch_password() {
 }
 
 list_profile_names() {
-  IFS=$'\n' read -d '' -r -a vpn_names < <(xmlstarlet sel -t -m "//VPN" -v "name" -n "$PROFILES_FILE")
+  profiles_xml_ok || return 1
+  IFS=$'\n' read -d '' -r -a vpn_names < <(xmlstarlet sel -t -m "//VPN" -v "name" -n "$PROFILES_FILE" 2>/dev/null)
   vpn_names+=("Quit")
   printf "%s\n" "${vpn_names[@]}"
 }
@@ -127,6 +143,7 @@ profile_exists() {
 # Tabular overview of all profiles (no secrets shown).
 list_profiles() {
   check_file_existence "$PROFILES_FILE" "Profiles"
+  profiles_xml_ok || return 1
   xmlstarlet sel -t -m '//VPN' \
       -v name -o $'\t' \
       -v protocol -o $'\t' \

--- a/service.sh
+++ b/service.sh
@@ -92,6 +92,7 @@ UNIT
 # Sanity checks before installing a service for a profile.
 _service_preflight() {
   local profile="$1"
+  profiles_xml_ok || return 1
   if ! profile_exists "$profile"; then
     print_danger "Unknown profile '%s'.\n" "$profile"
     return 1

--- a/setup.sh
+++ b/setup.sh
@@ -84,6 +84,9 @@ add_profile_wizard() {
   if [ ! -f "$PROFILES_FILE" ]; then
     ( umask 077; printf '<VPNs>\n</VPNs>\n' > "$PROFILES_FILE" )
   fi
+  # Don't try to append to a profiles file that isn't valid XML — xmlstarlet ed
+  # would fail confusingly. Fail with a clear message instead.
+  profiles_xml_ok || return 1
 
   local name proto host group user duo authmode tokenmode extraargs clientcert clientkey
   read -r -p "Profile name: " name
@@ -194,6 +197,7 @@ add_profile_wizard() {
 remove_profile() {
   local name="$1"
   [ -n "$name" ] || { echo "Usage: ${DISPLAY_NAME} remove-profile <profile>" >&2; return 1; }
+  profiles_xml_ok || return 1
   if ! profile_exists "$name"; then
     print_danger "Unknown profile '%s'.\n" "$name"
     return 1

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -136,3 +136,44 @@ XML
   [[ "$output" == *"VPN PROFILE 1"* ]]
   [[ "$output" == *"VPN PROFILE 2"* ]]
 }
+
+# --- graceful handling of a malformed profiles file (no leaked libxml2 errors) ---
+
+@test "profiles_xml_ok accepts a well-formed file and a missing file" {
+  run profiles_xml_ok                 # valid file written in setup()
+  [ "$status" -eq 0 ]
+  rm -f "$PROFILES_FILE"
+  run profiles_xml_ok                 # absent -> OK (handled by first-run logic)
+  [ "$status" -eq 0 ]
+}
+
+@test "profiles_xml_ok rejects malformed XML with a clear message and no parser noise" {
+  print_danger()  { printf -- "$1" "${@:2}"; }   # make messages observable
+  print_warning() { printf -- "$1" "${@:2}"; }
+  printf '<VPNs><VPN><name>Broken' > "$PROFILES_FILE"   # truncated: invalid XML
+  run profiles_xml_ok
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"isn't valid XML"* ]]
+  [[ "$output" != *"parser error"* ]]                  # no raw libxml2 leakage
+}
+
+@test "list_profiles on a malformed file fails gracefully (clear message, no libxml2 noise)" {
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_warning() { printf -- "$1" "${@:2}"; }
+  check_file_existence() { :; }
+  printf '<VPNs><VPN><name>Broken' > "$PROFILES_FILE"
+  run list_profiles
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"isn't valid XML"* ]]
+  [[ "$output" != *"parser error"* ]]
+  [[ "$output" != *"Double hyphen"* ]]
+}
+
+@test "list_profile_names on a malformed file returns non-zero instead of an empty menu" {
+  print_danger()  { :; }
+  print_warning() { :; }
+  printf '<VPNs><VPN><name>Broken' > "$PROFILES_FILE"
+  run list_profile_names
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Quit"* ]]          # didn't fall through to a bogus menu
+}


### PR DESCRIPTION
## Summary

Follow-up hardening to #71. Previously, if the profiles file was malformed XML, the commands that read it leaked raw `xmlstarlet`/libxml2 parser errors (`Double hyphen within comment`, `parser error …`) and `start` could **silently misread** the broken file as "no profiles" — wrongly dropping into the first-run wizard.

Now a single `profiles_xml_ok` guard (well-formedness via `xmlstarlet val`) is called at every profile-reading entry point — `start` (and its interactive menu), `list`, `add-profile`, `remove-profile`, `pin --save`, `service install` — so they print **one clear message** and return non-zero:

```
[DANGER] Your profiles file isn't valid XML, so it can't be read: ~/.config/vpn-up/vpn-up.command.profiles
[WARN]  Edit it to fix the XML (a common cause is an XML comment containing a double hyphen), or recreate a profile with 'vpn-up add-profile'.
```

## Changes
- **profiles.sh** — new `profiles_xml_ok` helper (missing file = OK; malformed = clear message + return 1, no raw libxml2 noise); guards in `list_profiles` and `list_profile_names`.
- **core.sh** — `start()` validates the profiles file up front, so malformed ≠ "no profiles".
- **setup.sh / network.sh / service.sh** — guards in `add_profile_wizard`, `remove_profile`, `pin_save`, `_service_preflight`.
- **tests/profiles.bats** — 4 new tests (valid/missing pass; malformed → clear message, non-zero, no `parser error`/`Double hyphen` leakage).
- **CHANGELOG / README badge** — v3.9.2.

## Verification
- `bats tests/` → **108 pass** (macOS local; CI runs macOS + Ubuntu); shellcheck clean.
- Manual: `list` against a malformed file prints the message above and exits 1 — no libxml2 noise.