### PR TITLE
Add first-class HTTP/SOCKS proxy profile field (v3.10.0)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — VPN Up for OpenConnect
 
-**Last updated:** 2026-06-18 (v3.9.0)
+**Last updated:** 2026-06-18 (v3.10.0)
 
 > *What* and *why* live in [PRD.md](PRD.md); this document covers *how*. Function and
 > file references are accurate as of the version above — verify against the source
@@ -89,10 +89,11 @@ namespace; `DISPLAY_NAME` (`vpn-up`) is used only in user-facing text.
 `password` (deprecated; migrated + blanked), `duo2FAMethod` (alias `duoMethod`),
 `serverCertificate`, `authMode` (`password` default | `sso`), `tokenMode`
 (empty | `totp`), `extraArgs` (verbatim openconnect flags), `clientCertificate` /
-`clientKey` (a file path or a PKCS#11 URI for client-certificate auth).
+`clientKey` (a file path or a PKCS#11 URI for client-certificate auth), `proxy` (an
+HTTP/SOCKS proxy URL → `--proxy`).
 `load_profile_fields` reads them positionally via `mapfile`, so **new fields are
 appended last** to avoid shifting indices (`extraArgs` is index 10,
-`clientCertificate`/`clientKey` are 11/12). Secrets are *not* in the XML — the TOTP
+`clientCertificate`/`clientKey` are 11/12, `proxy` is 13). Secrets are *not* in the XML — the TOTP
 **seed** (`token_secret`) and any client-key **passphrase / PKCS#11 PIN**
 (`key_password`) live in the secrets backend.
 
@@ -129,6 +130,8 @@ appended last** to avoid shifting indices (`extraArgs` is index 10,
      `_append_pkcs11_pin_source` writes the PIN to a transient `0600` file and adds
      `pin-source=file:…` to the URI (never the PIN on argv); the file is shredded
      after the session. A file-key passphrase is left to openconnect's TTY prompt.
+   - **Proxy:** an optional `proxy` URL is passed as `--proxy=` (an identifier, not a
+     secret); `--proxy` is on the collision watch list.
    - Background daemonizes (`--background`); foreground/service/SSO stay attached and
      the PID is captured via `pgrep` after a short delay (openconnect only writes
      `--pid-file` when daemonizing). `notify` + `run_hooks` fire on connect/disconnect.
@@ -169,8 +172,8 @@ unattended.
 
 - **Tests:** `bats` suite under [tests/](tests/) (`cli`, `core`, `lifecycle`, `logging`,
   `network`, `profiles`, `secrets`, `service`, `sso`, `totp`, `extraargs`,
-  `clientcert`, `ui_setup`), with stubs for network, sudo, keychain, oathtool, and
-  service managers.
+  `clientcert`, `proxy`, `ui_setup`), with stubs for network, sudo, keychain, oathtool,
+  and service managers.
 - **CI** ([.github/workflows/ci.yml](.github/workflows/ci.yml)): shellcheck +
   `bats tests/` on **macOS and Ubuntu** + gitleaks + CodeQL on every push/PR. `main` is
   protected and PR-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [v3.10.0] — 2026-06-18
+### Added
+
+- **First-class HTTP/SOCKS proxy** per profile (`<proxy>`, also an optional prompt in
+  `add-profile`). Set a proxy URL — e.g. `http://proxy.corp:8080` or
+  `socks5://127.0.0.1:1080` — and `vpn-up` passes it to openconnect's `--proxy` (it
+  previously required `<extraArgs>`). The URL is an identifier, not a secret, so it
+  lives in the profile XML; embedding inline `user:pass@` credentials is discouraged
+  since they would reach the command line.
+
+---
+
 ## [v3.9.2] — 2026-06-18
 ### Changed
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
 # Product Requirements Document — VPN Up for OpenConnect
 
-**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-18 (v3.9.0)
+**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-18 (v3.10.0)
 
 > This PRD describes *what* VPN Up is and *why*. For *how* it's built, see
 > [ARCHITECTURE.md](ARCHITECTURE.md). For the change history, see
@@ -141,6 +141,10 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
   vpn-up doesn't model (e.g. `--no-dtls`, `--os=win`, `--csd-wrapper`, a proxy, MTU)
   are tokenized quote-safely (via `xargs`, never `eval`) and appended before the
   gateway host; a token that duplicates a vpn-up-managed flag warns but still passes.
+- **FR-23** Allow a first-class **HTTP/SOCKS proxy** per profile (`proxy`): a URL
+  (e.g. `http://proxy:8080`, `socks5://host:1080`) passed to openconnect's `--proxy`.
+  The URL is an identifier, not a secret (it lives in the XML); embedding inline
+  credentials is discouraged since they would reach argv.
 
 ## 7. Non-functional requirements
 
@@ -184,7 +188,6 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 
 - RSA SecurID / Yubikey OATH (HOTP) token support (TOTP shipped in v3.8.0; PKCS#11
   client certificates, incl. Yubikey PIV, shipped in v3.9.0).
-- First-class HTTP/SOCKS proxy field (today a proxy can be passed via `extraArgs`).
 - Multiple simultaneous tunnels (per-profile state already lays the groundwork).
 
 ## 11. Release & distribution

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.9.2-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.10.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)
@@ -394,6 +394,18 @@ Authenticate with an **X.509 client certificate** — a file or a **PKCS#11** sm
 - For a [login service](#run-as-a-login-service-auto-reconnect), use a PKCS#11 token with a stored PIN, or an unencrypted `0600` key file (a passphrase-protected file key can't run unattended — there's no TTY to prompt on).
 - `vpn-up doctor` reports PKCS#11 (`p11-kit`) availability. Full guide: [docs/client-certificate-auth](https://sorinipate.github.io/vpn-up-for-openconnect/client-certificate-auth/).
 
+### HTTP/SOCKS proxy
+
+Reach the gateway through a proxy by setting `<proxy>` on the profile (or answer the optional proxy prompt in `add-profile`). It's passed to openconnect's `--proxy`:
+
+```xml
+<proxy>http://proxy.corp:8080</proxy>
+<!-- or SOCKS: -->
+<proxy>socks5://127.0.0.1:1080</proxy>
+```
+
+- The proxy URL is an **identifier, not a secret** — it lives in the profile XML. ⚠️ Avoid embedding `user:pass@` in the URL: like any argument, it would be visible in the process table. Prefer a proxy that doesn't require inline credentials.
+
 ---
 
 ## ⚙️ Configuration
@@ -432,11 +444,12 @@ Seeded from [config/vpn-up.command.profiles.default](config/vpn-up.command.profi
     <extraArgs>--no-dtls</extraArgs>
     <clientCertificate>/etc/vpn/me.pem</clientCertificate>
     <clientKey></clientKey>
+    <proxy>http://proxy.corp:8080</proxy>
   </VPN>
 </VPNs>
 ```
 
-Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login). `<tokenMode>` is empty (default) or `totp` for [authenticator-app 2FA](#totp-authenticator-app-2fa). `<extraArgs>` passes extra openconnect flags verbatim — see [Advanced: extra openconnect arguments](#advanced-extra-openconnect-arguments). `<clientCertificate>`/`<clientKey>` enable [client-certificate authentication](#client-certificate-authentication) — a file path or a PKCS#11 URI; a key passphrase/PIN goes in the secrets backend (`key_password`), never the XML.
+Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2FAMethod`. The `<password>` field is deprecated: plaintext values are migrated to the secrets backend and blanked in the XML automatically on first use — prefer `vpn-up set-secret`. A `duo2FAMethod` of `passcode` prompts for the one-time code at connect time. `<authMode>` is `password` (default) or `sso` for [browser-based SAML/SSO login](#sso--external-browser-login). `<tokenMode>` is empty (default) or `totp` for [authenticator-app 2FA](#totp-authenticator-app-2fa). `<extraArgs>` passes extra openconnect flags verbatim — see [Advanced: extra openconnect arguments](#advanced-extra-openconnect-arguments). `<clientCertificate>`/`<clientKey>` enable [client-certificate authentication](#client-certificate-authentication) — a file path or a PKCS#11 URI; a key passphrase/PIN goes in the secrets backend (`key_password`), never the XML. `<proxy>` routes the connection through an [HTTP/SOCKS proxy](#httpsocks-proxy).
 
 ---
 
@@ -445,7 +458,6 @@ Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2
 **Under consideration** (open an issue if you need one of these):
 
 - RSA SecurID / Yubikey OATH (HOTP) token support (TOTP authenticator codes are already supported — see [TOTP authenticator-app 2FA](#totp-authenticator-app-2fa) — as is a Yubikey **PIV client certificate** via [client-certificate authentication](#client-certificate-authentication))
-- HTTP/SOCKS proxy passthrough as a profile field
 - Multiple simultaneous tunnels (per-profile state files already lay the groundwork)
 
 **Explicitly out of scope:** Windows support, GUI.

--- a/config/vpn-up.command.profiles.default
+++ b/config/vpn-up.command.profiles.default
@@ -51,6 +51,11 @@
              token with a stored PIN. -->
         <clientCertificate></clientCertificate>
         <clientKey></clientKey>
+        <!-- proxy (optional): HTTP/SOCKS proxy URL for openconnect, e.g.
+             http://proxy.corp:8080 or socks5://127.0.0.1:1080. It is an
+             identifier, not a secret; avoid embedding user:pass in the URL
+             (that would put credentials on the command line). -->
+        <proxy></proxy>
     </VPN>
 
     <!-- VPN PROFILE 2 -->
@@ -77,6 +82,8 @@
              PKCS#11 PIN goes in the secrets backend (key_password), not here. -->
         <clientCertificate></clientCertificate>
         <clientKey></clientKey>
+        <!-- proxy: see VPN PROFILE 1 (HTTP/SOCKS proxy URL for openconnect). -->
+        <proxy></proxy>
     </VPN>
     <!-- Add more VPN profiles as needed -->
 </VPNs>

--- a/core.sh
+++ b/core.sh
@@ -412,7 +412,7 @@ _warn_extra_arg_collisions() {
   for tok in "$@"; do
     base="${tok%%=*}"
     case "$base" in
-      --protocol|-q|--user|--passwd-on-stdin|--background|--servercert|--authgroup|--pid-file|--external-browser|--token-mode|--token-secret|--certificate|-c|--sslkey|-k|--key-password)
+      --protocol|-q|--user|--passwd-on-stdin|--background|--servercert|--authgroup|--pid-file|--external-browser|--token-mode|--token-secret|--certificate|-c|--sslkey|-k|--key-password|--proxy)
         print_warning "extraArgs contains '%s', which vpn-up already manages; passing it anyway (may conflict).\n" "$base" ;;
     esac
   done
@@ -454,6 +454,8 @@ run_openconnect() {
   [ "$effective_background" = TRUE ] && args+=(--background)
   [ -n "$SERVER_CERTIFICATE" ] && args+=(--servercert="$SERVER_CERTIFICATE")
   [ -n "$VPN_GROUP" ] && args+=(--authgroup "$VPN_GROUP")
+  # Optional HTTP/SOCKS proxy (a URL, not a secret — safe on argv).
+  [ -n "${VPN_PROXY:-}" ] && args+=(--proxy="$VPN_PROXY")
   # Client-certificate auth (X.509). The cert/key may be a file path or a PKCS#11
   # URI (smartcard / YubiKey PIV) — an identifier, not a secret, so it is safe on
   # argv. A key passphrase / PKCS#11 PIN is a secret and must NOT hit argv: for a

--- a/profiles.sh
+++ b/profiles.sh
@@ -51,7 +51,8 @@ load_profile_fields() {
       -v "tokenMode | tokenmode" -n \
       -v "extraArgs | extraargs" -n \
       -v "clientCertificate | clientcertificate" -n \
-      -v "clientKey | clientkey" -n "${PROFILES_FILE}"
+      -v "clientKey | clientkey" -n \
+      -v "proxy | proxyUrl" -n "${PROFILES_FILE}"
   )
   VPN_NAME="${fields[0]:-}"
   PROTOCOL="${fields[1]:-}"
@@ -73,6 +74,9 @@ load_profile_fields() {
   # identifiers, not secrets; any passphrase/PIN lives in the secrets backend.
   VPN_CLIENT_CERT="${fields[11]:-}"
   VPN_CLIENT_KEY="${fields[12]:-}"
+  # Optional HTTP/SOCKS proxy URL (e.g. http://proxy:8080, socks5://127.0.0.1:1080)
+  # passed to openconnect. An identifier, not a secret — avoid embedding credentials.
+  VPN_PROXY="${fields[13]:-}"
 
   # Intentionally NOT exported: these are read only by functions in this
   # shell, and exporting would copy the password into the environment of

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ CFG
 # Append a <VPN> block to the profiles file (password stays empty — secrets
 # belong in the secrets backend, set separately).
 append_profile() {
-  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}" extraargs="${9:-}" clientcert="${10:-}" clientkey="${11:-}"
+  local name="$1" proto="$2" host="$3" group="$4" user="$5" duo="$6" authmode="${7:-password}" tokenmode="${8:-}" extraargs="${9:-}" clientcert="${10:-}" clientkey="${11:-}" proxy="${12:-}"
   local tmp="${PROFILES_FILE}.tmp"
   xmlstarlet ed \
     -s '/VPNs' -t elem -n VPN -v '' \
@@ -77,6 +77,7 @@ append_profile() {
     -s '/VPNs/VPN[last()]' -t elem -n extraArgs -v "$extraargs" \
     -s '/VPNs/VPN[last()]' -t elem -n clientCertificate -v "$clientcert" \
     -s '/VPNs/VPN[last()]' -t elem -n clientKey -v "$clientkey" \
+    -s '/VPNs/VPN[last()]' -t elem -n proxy -v "$proxy" \
     "${PROFILES_FILE}" > "${tmp}" && mv "${tmp}" "${PROFILES_FILE}" && chmod 600 "${PROFILES_FILE}"
 }
 
@@ -88,7 +89,7 @@ add_profile_wizard() {
   # would fail confusingly. Fail with a clear message instead.
   profiles_xml_ok || return 1
 
-  local name proto host group user duo authmode tokenmode extraargs clientcert clientkey
+  local name proto host group user duo authmode tokenmode extraargs clientcert clientkey proxy
   read -r -p "Profile name: " name
   [ -n "$name" ] || { print_danger "Profile name is required.\n"; return 1; }
   if profile_exists "$name"; then
@@ -165,11 +166,16 @@ add_profile_wizard() {
     esac
   fi
 
+  # Optional HTTP/SOCKS proxy. A URL, not a secret — avoid embedding credentials
+  # (they would land on openconnect's command line).
+  proxy=""
+  read -r -p "HTTP/SOCKS proxy (optional, e.g. http://proxy:8080 or socks5://host:1080): " proxy
+
   # Advanced (optional): extra openconnect flags passed verbatim at connect time.
   extraargs=""
   read -r -p "Extra openconnect arguments (advanced, optional): " extraargs
 
-  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" "$extraargs" "$clientcert" "$clientkey" \
+  append_profile "$name" "$proto" "$host" "$group" "$user" "$duo" "$authmode" "$tokenmode" "$extraargs" "$clientcert" "$clientkey" "$proxy" \
     || { print_danger "Failed to update %s\n" "$PROFILES_FILE"; return 1; }
   print_success "Added profile '%s' to %s\n" "$name" "$PROFILES_FILE"
 

--- a/tests/proxy.bats
+++ b/tests/proxy.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Tests for the first-class HTTP/SOCKS proxy field (<proxy>): it maps to
+# openconnect's --proxy and is appended only when set.
+
+setup() {
+  export PROGRAM_NAME="vpnup-test"
+  export PROGRAM_PATH="$BATS_TEST_TMPDIR"
+  export DATA_DIR="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$DATA_DIR/pids" "$DATA_DIR/logs"
+  export PROFILES_FILE="$DATA_DIR/profiles.xml"
+  print_warning() { printf -- "$1" "${@:2}"; }
+  print_danger()  { printf -- "$1" "${@:2}"; }
+  print_success() { printf -- "$1" "${@:2}"; }
+  print_primary() { printf -- "$1" "${@:2}"; }
+  notify() { :; }
+  source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../dependencies.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
+  source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+_write_profiles() {
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>Proxy VPN</name><protocol>anyconnect</protocol><host>p.example.com</host><authGroup></authGroup><user>alice</user><password></password><duo2FAMethod></duo2FAMethod><serverCertificate></serverCertificate><authMode>password</authMode><tokenMode></tokenMode><extraArgs></extraArgs><clientCertificate></clientCertificate><clientKey></clientKey><proxy>socks5://127.0.0.1:1080</proxy></VPN>
+  <VPN><name>Plain VPN</name><protocol>anyconnect</protocol><host>x.example.com</host><authGroup></authGroup><user>bob</user><password></password><duo2FAMethod>push</duo2FAMethod></VPN>
+</VPNs>
+XML
+}
+
+# --- schema ---
+
+@test "load_profile_fields reads proxy and leaves earlier fields intact" {
+  _write_profiles
+  load_profile_fields "Proxy VPN"
+  [ "$VPN_NAME" = "Proxy VPN" ]
+  [ "$VPN_USER" = "alice" ]
+  [ "$VPN_PROXY" = "socks5://127.0.0.1:1080" ]
+}
+
+@test "load_profile_fields leaves proxy empty when the tag is absent" {
+  _write_profiles
+  load_profile_fields "Plain VPN"
+  [ -z "$VPN_PROXY" ]
+  [ "$VPN_DUO2FAMETHOD" = "push" ]
+}
+
+# --- argv: --proxy present only when set ---
+
+@test "run_openconnect passes --proxy when the profile has one" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv"
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$argv"; cat >/dev/null; return 0; fi; return 0; }
+  load_profile_fields "Proxy VPN"
+  VPN_PASSWD="s3cret"
+  SERVER_CERTIFICATE="pin-sha256:abc"   # skip trust-store lookup
+  QUIET=FALSE; BACKGROUND=TRUE          # background branch (no tee/sleep)
+
+  connect
+
+  grep -qF -- "--proxy=socks5://127.0.0.1:1080" "$argv"
+}
+
+@test "run_openconnect omits --proxy when the profile has none" {
+  _write_profiles
+  local argv="$BATS_TEST_TMPDIR/argv"
+  sudo() { if [ "$1" = openconnect ]; then shift; printf '%s\n' "$@" > "$argv"; cat >/dev/null; return 0; fi; return 0; }
+  load_profile_fields "Plain VPN"
+  VPN_DUO2FAMETHOD=""                   # avoid the interactive passcode branch
+  VPN_PASSWD="s3cret"
+  SERVER_CERTIFICATE="pin-sha256:abc"
+  QUIET=FALSE; BACKGROUND=TRUE
+
+  connect
+
+  ! grep -qF -- "--proxy" "$argv"
+}
+
+# --- collision warning ---
+
+@test "_warn_extra_arg_collisions warns when extraArgs duplicates --proxy" {
+  run _warn_extra_arg_collisions "--proxy=http://x:8080"
+  [[ "$output" == *"--proxy"* ]]
+}


### PR DESCRIPTION
## Summary

First roadmap item: a first-class **`<proxy>`** profile field (the proxy previously required `<extraArgs>`). Set a URL and `vpn-up` passes it to openconnect's `--proxy`:

```xml
<proxy>http://proxy.corp:8080</proxy>
<!-- or -->
<proxy>socks5://127.0.0.1:1080</proxy>
```

Additive, non-interactive (service-mode compatible), no new dependency. The proxy URL is an **identifier, not a secret** — it lives in the profile XML and is safe on argv; embedding inline `user:pass@` credentials is discouraged (they'd reach the process table) and documented.

## Changes
- **profiles.sh** — parse `proxy` (schema index 13).
- **core.sh** — append `--proxy=` when set; add `--proxy` to the `extraArgs` collision watch list.
- **setup.sh** — `append_profile` arg + an optional wizard prompt.
- **config default** — `<proxy>` in both profiles, with a **double-hyphen-free** comment (avoids the v3.9.1 parse bug).
- **tests/proxy.bats** — schema parse (index 13), `--proxy` present when set / absent when empty, collision warning.
- **Docs** — README usage + schema + roadmap; PRD FR-23; ARCHITECTURE; CHANGELOG; badge → **v3.10.0**.

## Verification
- `bats tests/` → **113 pass** (macOS local; CI runs macOS + Ubuntu); shellcheck clean.
- `xmlstarlet val config/vpn-up.command.profiles.default` → valid; both placeholder names parse.
- Manual: `<proxy>socks5://127.0.0.1:1080</proxy>` → `--proxy=` in the captured argv; empty proxy adds no flag.