### PR TITLE
Docs: descope RSA SecurID (move to out-of-scope)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -176,8 +176,11 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 - On Linux, a root-spawned SSO browser may not reach the desktop session (mitigated by
   the `VPN_UP_EXTERNAL_BROWSER` override).
 - TOTP stores the seed beside the password in the same secret backend — effectively
-  "1.5-factor"; it's opt-in. RSA SecurID and Yubikey OATH (HOTP) tokens are not yet
-  supported (a Yubikey PIV *client certificate* is — see FR-22).
+  "1.5-factor"; it's opt-in. Yubikey OATH (HOTP) tokens are not yet supported (a
+  Yubikey PIV *client certificate* is — see FR-22). **RSA SecurID is out of scope**:
+  importing a SecurID token requires giving openconnect the token secret on the
+  command line (`--token-secret`), which violates NFR-1 (no secrets in argv) — the
+  same reason TOTP is fed on stdin rather than via `--token-secret`.
 - A **passphrase-protected client-certificate file** cannot run as a login service
   (no TTY to prompt on); use an unencrypted `0600` key or a PKCS#11 token with a
   stored PIN. A stored PKCS#11 PIN sits in the same secret backend as the password
@@ -186,8 +189,9 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 
 ## 10. Roadmap (under consideration)
 
-- RSA SecurID / Yubikey OATH (HOTP) token support (TOTP shipped in v3.8.0; PKCS#11
-  client certificates, incl. Yubikey PIV, shipped in v3.9.0).
+- Yubikey OATH (HOTP) token support (TOTP shipped in v3.8.0; PKCS#11 client
+  certificates, incl. Yubikey PIV, shipped in v3.9.0). *RSA SecurID is out of scope —
+  see §9.*
 - Multiple simultaneous tunnels (per-profile state already lays the groundwork).
 
 ## 11. Release & distribution

--- a/README.md
+++ b/README.md
@@ -457,10 +457,10 @@ Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2
 
 **Under consideration** (open an issue if you need one of these):
 
-- RSA SecurID / Yubikey OATH (HOTP) token support (TOTP authenticator codes are already supported — see [TOTP authenticator-app 2FA](#totp-authenticator-app-2fa) — as is a Yubikey **PIV client certificate** via [client-certificate authentication](#client-certificate-authentication))
+- Yubikey OATH (HOTP) token support (TOTP authenticator codes are already supported — see [TOTP authenticator-app 2FA](#totp-authenticator-app-2fa) — as is a Yubikey **PIV client certificate** via [client-certificate authentication](#client-certificate-authentication))
 - Multiple simultaneous tunnels (per-profile state files already lay the groundwork)
 
-**Explicitly out of scope:** Windows support, GUI.
+**Explicitly out of scope:** Windows support, GUI, and **RSA SecurID** — importing a SecurID token requires passing the token secret to openconnect on the command line (`--token-secret`), which would break VPN Up's rule of never putting secrets in argv (the same reason TOTP is fed on stdin rather than via `--token-secret`).
 
 **Known behavior:** some AnyConnect gateways emit an initial `Unexpected 404 result from server` — this is benign if the connection proceeds successfully.
 


### PR DESCRIPTION
## Summary

Removes **RSA SecurID** from the roadmap and lists it as **explicitly out of scope**, with the rationale: importing a SecurID token requires passing the token secret to openconnect on the command line (`--token-secret`), which would violate VPN Up's rule of never putting secrets in argv — the same reason TOTP is generated and fed on stdin rather than via `--token-secret`.

The remaining token-support roadmap item is now **Yubikey OATH (HOTP)** only.

- **README** — roadmap bullet drops "RSA SecurID /"; the "Explicitly out of scope" line gains RSA SecurID + reason.
- **PRD** — §10 roadmap bullet → HOTP only (points to §9); §9 limitations reframes RSA SecurID from "not yet supported" to "out of scope (violates NFR-1)".

Docs-only — no code, no version/CHANGELOG bump.

## Verification
- `grep -rn "RSA SecurID" README.md PRD.md` → all three mentions now frame it as out-of-scope; no `RSA SecurID /` roadmap coupling remains.
- shellcheck + bats + gitleaks unaffected.