### PR TITLE
Allow multiple simultaneous tunnels (distinct profiles)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,7 +54,7 @@ All modules are sourced by [vpn-up.command](vpn-up.command) in dependency order.
 | Module | Responsibility |
 |---|---|
 | **[vpn-up.command](vpn-up.command)** | Entry point. Bash≥4 guard, `set -u`, resolves `PROGRAM_NAME`/`PROGRAM_PATH`/`DATA_DIR`, one-time migration of legacy in-repo state, sources modules, and dispatches the subcommand `case`. Defines `DISPLAY_NAME` indirectly (via logging). |
-| **[logging.sh](logging.sh)** | Paths, print helpers (`print_primary/success/warning/danger`), portable `stat` wrappers (`file_owner_uid`, `file_mode` — GNU `-c` first, BSD `-f` fallback), `profile_slug`, per-profile path setup (`set_profile_paths`), PID helpers (`is_openconnect_pid`, `any_vpn_running`), `show_logs`. Defines `DISPLAY_NAME`. |
+| **[logging.sh](logging.sh)** | Paths, print helpers (`print_primary/success/warning/danger`), portable `stat` wrappers (`file_owner_uid`, `file_mode` — GNU `-c` first, BSD `-f` fallback), `profile_slug`, per-profile path helpers (`set_profile_paths`, `profile_*_file`, `profile_vpn_running`), PID helpers (`is_openconnect_pid`, `is_vpn_running`), `show_logs`. Defines `DISPLAY_NAME`. |
 | **[ui.sh](ui.sh)** | ASCII banner (`show_banner`, gated by `SHOW_BANNER` + TTY) and desktop notifications (`notify` → `osascript`/`notify-send`, gated by `NOTIFICATIONS`). |
 | **[dependencies.sh](dependencies.sh)** | `require_bin`, `check_dependencies`, `doctor`. Also `openconnect_major` / `require_openconnect_sso` (the openconnect ≥ 9.0 gate for SSO) and `require_oathtool` (the gate for TOTP). `doctor` also reports PKCS#11 (`p11-kit`) availability for client certs. |
 | **[encryption.sh](encryption.sh)** | Secret backend abstraction: `secrets_set/get/delete`, `secrets_backend` selection (macOS Keychain via `security -i` stdin; Linux Secret Service via `secret-tool`; OpenSSL AES-256-CBC + PBKDF2 vault fallback). Namespacing via `secrets_key`. |
@@ -101,8 +101,9 @@ appended last** to avoid shifting indices (`extraArgs` is index 10,
 
 ### 5.1 `start` → `connect` → `run_openconnect`
 1. **`start`** ensures config exists (else `setup_wizard`), loads it (`load_config`
-   after `assert_safe_to_source`), handles the no-profiles first-run, runs network +
-   already-running checks, then selects a profile (named or interactive menu).
+   after `assert_safe_to_source`), handles the no-profiles first-run, runs the
+   network check, then selects a profile (named or interactive menu). Different
+   profiles may run at the same time; a same-profile duplicate is refused.
 2. `load_profile_fields` populates shell vars. For non-SSO profiles,
    `migrate_or_fetch_password` retrieves the secret (migrating legacy plaintext).
 3. **`connect`** validates host/protocol, then branches on auth with precedence
@@ -133,8 +134,9 @@ appended last** to avoid shifting indices (`extraArgs` is index 10,
    - **Proxy:** an optional `proxy` URL is passed as `--proxy=` (an identifier, not a
      secret); `--proxy` is on the collision watch list.
    - Background daemonizes (`--background`); foreground/service/SSO stay attached and
-     the PID is captured via `pgrep` after a short delay (openconnect only writes
-     `--pid-file` when daemonizing). `notify` + `run_hooks` fire on connect/disconnect.
+     the PID is captured after a short delay by matching the openconnect argv to
+     this profile's `--pid-file` (openconnect only writes `--pid-file` when
+     daemonizing). `notify` + `run_hooks` fire on connect/disconnect.
 
 ### 5.2 Browser-command resolution (SSO)
 `resolve_external_browser`: `VPN_UP_EXTERNAL_BROWSER` override → bundled
@@ -186,10 +188,14 @@ unattended.
   a dependency and positional field loading (mitigated by append-only schema growth).
 - **Positional `mapfile` field loading** — fast and empty-field-safe (vs. `read -d`
   which collapses blank fields); requires new fields to be appended last.
-- **One connection at a time** — per-profile state files make `status`/`stop`/`logs`
-  accurate without the complexity of concurrent tunnels.
-- **Wrapper, foreground PID capture via `pgrep`** — openconnect writes `--pid-file` only
-  when daemonizing, so foreground/service/SSO sessions self-record after a short delay.
+- **Multiple simultaneous tunnels** — per-profile PID/state/log files let
+  `status`/`stop`/`logs` track each OpenConnect process independently. Starting the
+  same profile twice is refused, but different profiles can run side by side when
+  their gateway-pushed routes/DNS settings can coexist.
+- **Wrapper, foreground PID capture via argv matching** — openconnect writes
+  `--pid-file` only when daemonizing, so foreground/service/SSO sessions
+  self-record after a short delay by finding the openconnect process launched with
+  that profile's PID file.
 - **SSO forced foreground, no stdin pipe** — the single most important correctness
   detail for browser auth; the TTY must stay attached.
 - **TOTP generated client-side, fed on stdin** — the seed stays in the keychain and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [Unreleased]
+### Added
+
+- **Multiple simultaneous tunnels**. `vpn-up start` now allows different profiles
+  to run side by side using the existing per-profile PID/state/log layout, while
+  still refusing to start the same profile twice. `status`, `stop [profile]`, and
+  `logs [profile]` remain profile-aware.
+
+### Changed
+
+- Foreground, service, and SSO sessions now record their PID by matching the
+  openconnect process launched with that profile's `--pid-file`, instead of
+  assuming the newest openconnect process belongs to the current start command.
+
+---
+
 ## [v3.10.0] — 2026-06-18
 ### Added
 

--- a/PRD.md
+++ b/PRD.md
@@ -16,7 +16,7 @@ Linux users connect to Cisco AnyConnect, Palo Alto GlobalProtect, Pulse Secure,
 Juniper Network Connect, and ocserv gateways from the terminal — with named
 profiles, Duo 2FA, TOTP authenticator codes, browser-based SSO, client-certificate
 auth (incl. PKCS#11 smartcards / YubiKey PIV), certificate pinning, secure secret
-storage, auto-reconnect, and shell completion.
+storage, multiple simultaneous tunnels, auto-reconnect, and shell completion.
 
 It is a *wrapper*, not a fork: OpenConnect does the tunnelling; VPN Up provides the
 profile management, credential hygiene, and lifecycle ergonomics that raw
@@ -54,7 +54,8 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 - **Never** store or expose credentials in plaintext, argv, or child-process environments.
 - Support the **authentication methods real gateways use**: password, Duo 2FA
   (push/phone/sms/passcode), TOTP authenticator codes, and browser-based SAML/SSO.
-- Provide **lifecycle ergonomics**: status, stop, logs, restart, auto-reconnect at login.
+- Provide **lifecycle ergonomics**: status, stop, logs, restart, simultaneous
+  compatible tunnels, auto-reconnect at login.
 - Be **safe by default** (fail-closed server identity) and **auditable** (small, modular Bash).
 - Run identically on **macOS and Linux**.
 
@@ -62,8 +63,6 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 - **Windows support** — explicitly out of scope.
 - **A GUI** — terminal-first by design.
 - **Replacing OpenConnect** — VPN Up orchestrates it; it does not reimplement tunnelling.
-- **Multiple simultaneous tunnels** — one active connection at a time (per-profile
-  state files make bookkeeping accurate, not the tunnels concurrent). Under consideration.
 
 ## 4. Target users & personas
 
@@ -78,7 +77,9 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 
 - *As a developer*, I run `vpn-up start "Work"` and I'm connected after a single Duo
   push — no password typed, no command to remember.
-- *As a consultant*, I keep five client profiles and pick one from a menu (`vpn-up start`).
+- *As a consultant*, I keep five client profiles, pick one from a menu
+  (`vpn-up start`), and keep two compatible client tunnels up when their routes do
+  not overlap.
 - *As an SSO user*, I mark a profile `authMode=sso`, and `vpn-up start` opens my
   browser for the Okta/Azure/Ping + Duo login, then the tunnel comes up.
 - *As a remote worker*, I run `vpn-up service install "Work"` so the VPN connects at
@@ -131,6 +132,10 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
   (launchd on macOS, systemd user unit on Linux). SSO and passcode profiles are refused (interactive).
 - **FR-15** Lifecycle hooks: user scripts in `hooks/connected.d` / `hooks/disconnected.d`,
   run with `VPN_EVENT`/`VPN_NAME`/`VPN_HOST` (never the password), skipped unless safely owned.
+- **FR-24** Multiple simultaneous tunnels: different profiles can be connected
+  at the same time, with per-profile PID/state/log files. Starting the same
+  profile twice is refused. Route and DNS compatibility remains governed by
+  OpenConnect and gateway-pushed settings.
 
 ### 6.4 Management & diagnostics
 - **FR-16** Guided `setup` wizard and `add-profile` / `remove-profile` (handle XML, secrets, pins, services).
@@ -170,7 +175,10 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 
 ## 9. Out of scope / explicit limitations
 
-- Windows; GUI; concurrent multi-tunnel.
+- Windows; GUI.
+- Simultaneous full-tunnel VPNs can conflict over the default route or DNS. VPN Up
+  manages each OpenConnect process independently, but OpenConnect and the gateways
+  still own route/DNS installation.
 - SSO under a non-interactive login service (requires a desktop session).
 - SSO on the `nc` protocol (unsupported by OpenConnect).
 - On Linux, a root-spawned SSO browser may not reach the desktop session (mitigated by
@@ -192,7 +200,6 @@ upgrades. There is a gap for a **terminal-first, secure, scriptable** front end.
 - Yubikey OATH (HOTP) token support (TOTP shipped in v3.8.0; PKCS#11 client
   certificates, incl. Yubikey PIV, shipped in v3.9.0). *RSA SecurID is out of scope —
   see §9.*
-- Multiple simultaneous tunnels (per-profile state already lays the groundwork).
 
 ## 11. Release & distribution
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ VPN is running (PID: 88933)
 
 ---
 
-**VPN Up** is a secure, scriptable command-line VPN manager for [OpenConnect](https://www.infradead.org/openconnect/). It connects macOS and Linux machines to **Cisco AnyConnect**, Palo Alto **GlobalProtect**, **Pulse Secure**, **Juniper Network Connect**, and **ocserv** gateways straight from the terminal — with named profiles, Duo 2FA, certificate pinning, secure secret storage, auto-reconnect, and shell completion.
+**VPN Up** is a secure, scriptable command-line VPN manager for [OpenConnect](https://www.infradead.org/openconnect/). It connects macOS and Linux machines to **Cisco AnyConnect**, Palo Alto **GlobalProtect**, **Pulse Secure**, **Juniper Network Connect**, and **ocserv** gateways straight from the terminal — with named profiles, simultaneous tunnels, Duo 2FA, certificate pinning, secure secret storage, auto-reconnect, and shell completion.
 
 It's built for developers, consultants, DevOps engineers, and remote workers who'd rather drive their VPN from the command line than a vendor GUI.
 
 ## ❓ Why use VPN Up?
 
 - Connect to Cisco AnyConnect-compatible VPNs without the official GUI client
-- Manage multiple OpenConnect VPN profiles and connect by name (`vpn-up start "Work VPN"`)
+- Manage multiple OpenConnect VPN profiles, connect by name, and run compatible profiles side by side (`vpn-up start "Work VPN"`)
 - Use **Duo 2FA** from the command line — push, phone, SMS, or one-time passcode
 - Store VPN secrets in the macOS **Keychain**, Linux **Secret Service**, or an encrypted OpenSSL vault — never in plaintext config files
 - Run VPN connections as **launchd/systemd login services** with auto-reconnect
@@ -58,7 +58,7 @@ VPN Up is useful if you:
 - Use OpenConnect instead of vendor VPN clients
 - Connect to Cisco AnyConnect, GlobalProtect, Pulse Secure, Juniper, or ocserv VPNs
 - Want a terminal-first VPN workflow on macOS or Linux
-- Juggle multiple client VPN profiles on one machine
+- Juggle multiple client VPN profiles on one machine, including simultaneous tunnels when their routes can coexist
 - Need Duo 2FA support from the command line
 - Want secure password storage without plaintext config files
 - Want VPN auto-reconnect at login via launchd or systemd
@@ -95,7 +95,7 @@ VPN Up is useful if you:
 
 ### Connect
 - **Four SSL VPN protocols** via [OpenConnect](https://www.infradead.org/openconnect/): Cisco **AnyConnect** (and ocserv), Juniper **Network Connect**, Palo Alto **GlobalProtect**, and **Pulse Secure**
-- **Multiple VPN profiles** — pick from an interactive menu or connect by name with zero prompts (`vpn-up start "Work VPN"`), with full **AuthGroup/realm** support
+- **Multiple VPN profiles and tunnels** — pick from an interactive menu or connect by name with zero prompts (`vpn-up start "Work VPN"`), with full **AuthGroup/realm** support; compatible profiles can stay connected at the same time
 - **Duo 2FA** — `push`, `phone`, `sms`, or one-time passcodes prompted at connect time; empty method lets the gateway auto-push
 - **TOTP authenticator-app 2FA** — store the seed once and `vpn-up` generates the code at connect time (via `oathtool`); fully non-interactive, so it works as an auto-reconnecting login service
 - **SSO / external-browser login** — for gateways that force a browser-based SAML/SSO flow (Okta, Azure AD, Ping Identity, often with an embedded Duo iframe), via OpenConnect's `--external-browser` (needs openconnect ≥ 9.0). Because the login runs in your **real** browser, **passkeys / FIDO2 / YubiKey-WebAuthn work automatically**
@@ -109,7 +109,7 @@ VPN Up is useful if you:
 - **Isolated user data** — config, profiles, secrets, and logs live in `~/.config/vpn-up` with `600`/`700` permissions, untouched by updates or reinstalls
 
 ### Operate
-- **Profile-aware lifecycle** — `status` shows profile, gateway, and uptime; `stop` and `logs -f` target a specific connection
+- **Profile-aware lifecycle** — `status` shows every running tunnel with profile, gateway, and uptime; `stop` and `logs -f` target a specific connection
 - **Login service with auto-reconnect** — launchd (macOS) / systemd (Linux) supervision; reconnects when the tunnel drops
 - **Lifecycle hooks** — run your own scripts on connect/disconnect (mount shares, switch proxies)
 - **Desktop notifications** on connect/disconnect (Notification Center / `notify-send`)
@@ -226,12 +226,12 @@ vpn-up start "Frankfurt VPN"       # connect directly (scriptable)
 vpn-up list                        # list configured profiles
 vpn-up add-profile                 # guided profile creation (+ secret, + pin)
 vpn-up remove-profile "Old VPN"    # remove profile + secret + logs + service
-vpn-up status                      # profile, gateway, uptime
+vpn-up status                      # all running profiles, gateways, uptime
 vpn-up logs -f                     # follow the connection log
-vpn-up stop                        # stop the VPN (or: stop "Frankfurt VPN")
+vpn-up stop                        # stop all VPNs (or: stop "Frankfurt VPN")
 ```
 
-Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so `status`, `stop`, and `logs` are profile-aware.
+Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so `status`, `stop`, and `logs` are profile-aware. You can connect multiple different profiles at once; starting the same profile twice is refused. Whether two tunnels coexist cleanly still depends on the routes and DNS settings pushed by their gateways — split-tunnel or non-overlapping routes are the safest fit.
 
 ### TOTP authenticator-app 2FA
 
@@ -458,11 +458,10 @@ Supported tag aliases: `username`/`user`, `group`/`authGroup`, `duoMethod`/`duo2
 **Under consideration** (open an issue if you need one of these):
 
 - Yubikey OATH (HOTP) token support (TOTP authenticator codes are already supported — see [TOTP authenticator-app 2FA](#totp-authenticator-app-2fa) — as is a Yubikey **PIV client certificate** via [client-certificate authentication](#client-certificate-authentication))
-- Multiple simultaneous tunnels (per-profile state files already lay the groundwork)
 
 **Explicitly out of scope:** Windows support, GUI, and **RSA SecurID** — importing a SecurID token requires passing the token secret to openconnect on the command line (`--token-secret`), which would break VPN Up's rule of never putting secrets in argv (the same reason TOTP is fed on stdin rather than via `--token-secret`).
 
-**Known behavior:** some AnyConnect gateways emit an initial `Unexpected 404 result from server` — this is benign if the connection proceeds successfully.
+**Known behavior:** some AnyConnect gateways emit an initial `Unexpected 404 result from server` — this is benign if the connection proceeds successfully. Simultaneous full-tunnel VPNs can also fight over the default route or DNS. VPN Up tracks and controls each OpenConnect process independently, but OpenConnect and the VPN gateways still own route/DNS installation.
 
 ---
 

--- a/core.sh
+++ b/core.sh
@@ -51,6 +51,15 @@ load_config() {
   source "$CONFIGURATION_FILE"
 }
 
+ensure_profile_not_running() {
+  set_profile_paths "$VPN_NAME"
+  if profile_vpn_running "$VPN_NAME"; then
+    print_warning "VPN profile '%s' is already running. Run '%s status' or '%s stop \"%s\"' first.\n" "${VPN_NAME}" "${DISPLAY_NAME}" "${DISPLAY_NAME}" "${VPN_NAME}"
+    return 1
+  fi
+  return 0
+}
+
 start() {
   local requested="${1:-}"
   # Ensure config exists or run wizard
@@ -100,11 +109,6 @@ start() {
     exit 1
   fi
 
-  if any_vpn_running; then
-    print_warning "Already connected to a VPN! Run '%s status' or '%s stop' first.\n" "${DISPLAY_NAME}" "${DISPLAY_NAME}"
-    exit 1
-  fi
-
   print_primary "Starting ${DISPLAY_NAME} ...\n"
 
   if [ -n "$requested" ]; then
@@ -115,6 +119,7 @@ start() {
       exit 1
     fi
     load_profile_fields "$requested"
+    ensure_profile_not_running || exit 1
     if [ "${VPN_AUTH_MODE:-password}" != sso ]; then
       migrate_or_fetch_password || exit 1
     fi
@@ -130,6 +135,9 @@ start() {
       fi
       if printf "%s\n" "${vpn_names[@]}" | grep -qx -- "$option"; then
         load_profile_fields "$option"
+        if ! ensure_profile_not_running; then
+          continue
+        fi
         if [ "${VPN_AUTH_MODE:-password}" != sso ]; then
           migrate_or_fetch_password || exit 1
         fi
@@ -405,6 +413,34 @@ _append_pkcs11_pin_source() {
   printf '%s%spin-source=file:%s' "$uri" "$sep" "$pinfile"
 }
 
+_openconnect_pid_for_pid_file() {
+  local pidfile="$1"
+  { ps axww -o pid= -o command= 2>/dev/null || ps -eo pid= -o args= 2>/dev/null; } \
+    | awk -v pidfile="$pidfile" '
+        {
+          exe = $2
+          sub(/^.*\//, "", exe)
+          if (exe == "openconnect" && index($0, "--pid-file") && index($0, pidfile)) {
+            pid = $1
+          }
+        }
+        END { if (pid != "") print pid }
+      '
+}
+
+_record_foreground_openconnect_pid() {
+  (
+    sleep 3
+    local _pid
+    _pid="$(_openconnect_pid_for_pid_file "$PID_FILE_PATH")"
+    if [ -n "$_pid" ]; then
+      printf '%s\n' "$_pid" > "$PID_FILE_PATH"
+      notify "VPN Up" "Connected to ${VPN_NAME}"
+      run_hooks connected "${VPN_NAME}" "${VPN_HOST}"
+    fi
+  ) &
+}
+
 # Warn (but don't block) when a user-supplied extra arg duplicates a flag that
 # vpn-up already manages — overriding these can break connection or status/stop.
 _warn_extra_arg_collisions() {
@@ -515,14 +551,7 @@ run_openconnect() {
     # NOTHING on stdin. Always foreground; capture the PID the same way as the
     # foreground password path so status/stop work during the session.
     write_connection_state
-    ( sleep 3
-      _pid="$(pgrep -n -x openconnect 2>/dev/null || true)"
-      if [ -n "$_pid" ]; then
-        printf '%s\n' "$_pid" > "$PID_FILE_PATH"
-        notify "VPN Up" "Connected to ${VPN_NAME}"
-        run_hooks connected "${VPN_NAME}" "${VPN_HOST}"
-      fi
-    ) &
+    _record_foreground_openconnect_pid
     sudo openconnect "${args[@]}" 2>&1 | tee -a "$LOG_FILE_PATH"
     rm -f "$PID_FILE_PATH" "$STATE_FILE_PATH"
     notify "VPN Up" "Disconnected from ${VPN_NAME:-VPN}"
@@ -539,14 +568,7 @@ run_openconnect() {
     # record the PID ourselves (after the tunnel has had time to come up) so
     # status/stop work during a foreground/service session.
     write_connection_state
-    ( sleep 3
-      _pid="$(pgrep -n -x openconnect 2>/dev/null || true)"
-      if [ -n "$_pid" ]; then
-        printf '%s\n' "$_pid" > "$PID_FILE_PATH"
-        notify "VPN Up" "Connected to ${VPN_NAME}"
-        run_hooks connected "${VPN_NAME}" "${VPN_HOST}"
-      fi
-    ) &
+    _record_foreground_openconnect_pid
     printf "%s\n" "$stdin_lines" \
       | sudo openconnect "${args[@]}" 2>&1 | tee -a "$LOG_FILE_PATH"
     # Foreground session over (disconnect or failure): clean our records.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ See the [installation guide]({{ '/installation/' | relative_url }}) for manual s
 ## Why VPN Up?
 
 - Connect to Cisco AnyConnect-compatible VPNs **without the vendor GUI client**
-- Manage **multiple VPN profiles** and connect by name (`vpn-up start "Work"`)
+- Manage **multiple VPN profiles**, connect by name, and run compatible tunnels side by side (`vpn-up start "Work"`)
 - **Duo 2FA** from the command line — push, phone, SMS, or one-time passcode
 - **Browser-based SSO** (Okta, Azure AD, Ping Identity) for gateways that force an external browser login
 - Secrets in the macOS **Keychain**, Linux **Secret Service**, or an encrypted vault — never plaintext

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,8 @@ layout: page
 title: Usage
 description: >-
   Connect to a VPN from the command line with VPN Up: named profiles, status,
-  stop, logs, certificate pinning, login service with auto-reconnect, and hooks.
+  stop, logs, simultaneous tunnels, certificate pinning, login service with
+  auto-reconnect, and hooks.
 permalink: /usage/
 ---
 
@@ -28,14 +29,17 @@ vpn-up start "Frankfurt VPN"       # connect directly (scriptable)
 vpn-up list                        # list configured profiles (name, protocol, host, 2FA, auth)
 vpn-up add-profile                 # guided profile creation
 vpn-up remove-profile "Old VPN"    # remove profile + secret + logs + service
-vpn-up status                      # profile, gateway, uptime
+vpn-up status                      # all running profiles, gateways, uptime
 vpn-up logs -f                     # follow the connection log
-vpn-up stop                        # stop the VPN (or: stop "Frankfurt VPN")
+vpn-up stop                        # stop all VPNs (or: stop "Frankfurt VPN")
 vpn-up doctor                      # diagnose environment & secret backend
 ```
 
 Each profile keeps its own log and PID/state files under `~/.config/vpn-up`, so
-`status`, `stop`, and `logs` are profile-aware.
+`status`, `stop`, and `logs` are profile-aware. Multiple different profiles can
+be connected at the same time; starting the same profile twice is refused. Route
+and DNS compatibility still depends on what each gateway pushes, so split-tunnel
+or non-overlapping routes are the safest simultaneous setup.
 
 ## Secure secret storage
 

--- a/logging.sh
+++ b/logging.sh
@@ -25,19 +25,36 @@ file_mode()      { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/nu
 # Point the PID/LOG/STATE globals at a specific profile's files.
 # shellcheck disable=SC2034  # globals are consumed by core.sh
 set_profile_paths() {
-  local slug; slug="$(profile_slug "$1")"
-  PID_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.pid"
-  STATE_FILE_PATH="${DATA_DIR}/pids/${PROGRAM_NAME}.${slug}.state"
-  LOG_FILE_PATH="${DATA_DIR}/logs/${PROGRAM_NAME}.${slug}.log"
+  PID_FILE_PATH="$(profile_pid_file "$1")"
+  STATE_FILE_PATH="$(profile_state_file "$1")"
+  LOG_FILE_PATH="$(profile_log_file "$1")"
 }
 
-# True if any PID file (legacy or per-profile) points at a live openconnect.
-any_vpn_running() {
-  local f
-  for f in "${DATA_DIR}/pids/"*.pid; do
-    [ -e "$f" ] || continue
-    is_openconnect_pid "$(cat "$f")" && return 0
-  done
+profile_pid_file() {
+  local slug; slug="$(profile_slug "$1")"
+  printf '%s/pids/%s.%s.pid' "$DATA_DIR" "$PROGRAM_NAME" "$slug"
+}
+
+profile_state_file() {
+  local slug; slug="$(profile_slug "$1")"
+  printf '%s/pids/%s.%s.state' "$DATA_DIR" "$PROGRAM_NAME" "$slug"
+}
+
+profile_log_file() {
+  local slug; slug="$(profile_slug "$1")"
+  printf '%s/logs/%s.%s.log' "$DATA_DIR" "$PROGRAM_NAME" "$slug"
+}
+
+profile_vpn_running() {
+  local pidfile statefile pid
+  pidfile="$(profile_pid_file "$1")"
+  statefile="$(profile_state_file "$1")"
+  [ -f "$pidfile" ] || return 1
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  if is_openconnect_pid "$pid"; then
+    return 0
+  fi
+  rm -f "$pidfile" "$statefile"
   return 1
 }
 

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -14,7 +14,27 @@ setup() {
   print_primary() { printf -- "$1" "${@:2}"; }
   notify() { :; }
   source "$BATS_TEST_DIRNAME/../logging.sh"
+  source "$BATS_TEST_DIRNAME/../profiles.sh"
   source "$BATS_TEST_DIRNAME/../core.sh"
+}
+
+_write_start_test_profiles() {
+  cat > "$PROFILES_FILE" <<'XML'
+<VPNs>
+  <VPN><name>Work VPN</name><protocol>anyconnect</protocol><host>work.example.com</host><user>alice</user><password></password></VPN>
+  <VPN><name>Lab VPN</name><protocol>gp</protocol><host>lab.example.com</host><user>bob</user><password></password></VPN>
+</VPNs>
+XML
+}
+
+_write_start_test_config() {
+  cat > "$CONFIGURATION_FILE" <<'EOF'
+BACKGROUND=FALSE
+QUIET=TRUE
+SHOW_BANNER=FALSE
+NOTIFICATIONS=FALSE
+EOF
+  chmod 600 "$CONFIGURATION_FILE"
 }
 
 # --- assert_safe_to_source ---
@@ -62,6 +82,54 @@ setup() {
   [[ "$output" == *"not running"* ]]
   [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Stale.pid" ]
   [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Stale.state" ]
+}
+
+# --- start concurrency guard ---
+
+@test "start allows a different profile while another tunnel is running" {
+  _write_start_test_profiles
+  _write_start_test_config
+  echo 111 > "$DATA_DIR/pids/${PROGRAM_NAME}.Work_VPN.pid"
+  is_openconnect_pid() { [ "$1" = "111" ]; }
+  is_network_available() { return 0; }
+  show_banner() { :; }
+  migrate_or_fetch_password() { :; }
+  connect() { printf 'connected:%s\n' "$VPN_NAME"; }
+
+  run start "Lab VPN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected:Lab VPN"* ]]
+}
+
+@test "start refuses a profile that is already running" {
+  _write_start_test_profiles
+  _write_start_test_config
+  echo 111 > "$DATA_DIR/pids/${PROGRAM_NAME}.Work_VPN.pid"
+  is_openconnect_pid() { [ "$1" = "111" ]; }
+  is_network_available() { return 0; }
+  show_banner() { :; }
+  migrate_or_fetch_password() { echo "migrate-called"; }
+  connect() { echo "connect-called"; }
+
+  run start "Work VPN"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already running"* ]]
+  [[ "$output" != *"migrate-called"* ]]
+  [[ "$output" != *"connect-called"* ]]
+}
+
+@test "_openconnect_pid_for_pid_file matches the openconnect process with that pid file" {
+  ps() {
+    cat <<EOF
+ 100 openconnect --user=a --pid-file /tmp/a.pid vpn-a.example.com
+ 200 /usr/sbin/openconnect --user=b --pid-file /tmp/b.pid vpn-b.example.com
+ 300 sudo openconnect --user=b --pid-file /tmp/b.pid vpn-b.example.com
+EOF
+  }
+
+  run _openconnect_pid_for_pid_file "/tmp/b.pid"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
 }
 
 # --- stop ---

--- a/tests/logging.bats
+++ b/tests/logging.bats
@@ -16,6 +16,12 @@ setup() {
   [ "$LOG_FILE_PATH" = "$DATA_DIR/logs/${PROGRAM_NAME}.My_Work_VPN.log" ]
 }
 
+@test "profile path helpers return slugged per-profile files" {
+  [ "$(profile_pid_file "My Work VPN")" = "$DATA_DIR/pids/${PROGRAM_NAME}.My_Work_VPN.pid" ]
+  [ "$(profile_state_file "My Work VPN")" = "$DATA_DIR/pids/${PROGRAM_NAME}.My_Work_VPN.state" ]
+  [ "$(profile_log_file "My Work VPN")" = "$DATA_DIR/logs/${PROGRAM_NAME}.My_Work_VPN.log" ]
+}
+
 @test "is_openconnect_pid rejects empty, non-numeric, and non-openconnect pids" {
   run is_openconnect_pid "";        [ "$status" -ne 0 ]
   run is_openconnect_pid "12a4";    [ "$status" -ne 0 ]
@@ -24,11 +30,19 @@ setup() {
   run is_openconnect_pid "$$";      [ "$status" -ne 0 ]
 }
 
-@test "any_vpn_running scans pid files and survives an empty pids dir" {
-  run any_vpn_running; [ "$status" -ne 0 ]
-  echo "$$" > "$DATA_DIR/pids/a.pid"
-  is_openconnect_pid() { return 0; }
-  any_vpn_running
+@test "profile_vpn_running targets one profile and prunes stale state" {
+  echo 111 > "$DATA_DIR/pids/${PROGRAM_NAME}.Work_VPN.pid"
+  touch "$DATA_DIR/pids/${PROGRAM_NAME}.Work_VPN.state"
+  is_openconnect_pid() { [ "$1" = "111" ]; }
+  profile_vpn_running "Work VPN"
+  run profile_vpn_running "Lab VPN"
+  [ "$status" -ne 0 ]
+
+  is_openconnect_pid() { return 1; }
+  run profile_vpn_running "Work VPN"
+  [ "$status" -ne 0 ]
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Work_VPN.pid" ]
+  [ ! -e "$DATA_DIR/pids/${PROGRAM_NAME}.Work_VPN.state" ]
 }
 
 @test "file_mode and file_owner_uid report correct values" {


### PR DESCRIPTION
Replace the global "any VPN running" startup guard with a per-profile guard so different profiles can connect at the same time, while starting the same profile twice is still refused.

- core.sh: add ensure_profile_not_running (per-profile) and use it in both the named and interactive start flows; drop the global any_vpn_running block.
- core.sh: capture the foreground/SSO PID by matching the openconnect process launched with this profile's --pid-file (_openconnect_pid_for_pid_file) instead of pgrep -n -x openconnect, so one tunnel never records another tunnel's PID.
- logging.sh: split per-profile path helpers (profile_pid_file/ profile_state_file/profile_log_file) and add profile_vpn_running; remove the now-unused any_vpn_running helper.
- status/stop/logs and service.sh were already per-profile, so multiple login services for distinct profiles work without further changes.
- Update PRD, ARCHITECTURE, README, docs, and CHANGELOG. Route/DNS conflicts remain governed by OpenConnect and gateway-pushed settings; split-tunnel / non-overlapping routes are the realistic happy path.