### PR TITLE
Release v3.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 config/vpn-up.command.profiles
 config/vpn-up.command.config
+# Local Claude Code session/permission files (may capture secrets/tokens)
+.claude/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — VPN Up for OpenConnect
 
-**Last updated:** 2026-06-18 (v3.10.0)
+**Last updated:** 2026-06-19 (v3.11.0)
 
 > *What* and *why* live in [PRD.md](PRD.md); this document covers *how*. Function and
 > file references are accurate as of the version above — verify against the source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
-## [Unreleased]
+## [v3.11.0] — 2026-06-19
 ### Added
 
 - **Multiple simultaneous tunnels**. `vpn-up start` now allows different profiles

--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
 # Product Requirements Document — VPN Up for OpenConnect
 
-**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-18 (v3.10.0)
+**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-19 (v3.11.0)
 
 > This PRD describes *what* VPN Up is and *why*. For *how* it's built, see
 > [ARCHITECTURE.md](ARCHITECTURE.md). For the change history, see

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.10.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.11.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)


### PR DESCRIPTION
Stamps the **v3.11.0** release.

- Promote the `[Unreleased]` CHANGELOG section → `[v3.11.0] — 2026-06-19`
  (multiple simultaneous tunnels + argv-based PID capture, from #79).
- Bump the README release badge to v3.11.0.
- Update the ARCHITECTURE / PRD "Last updated" headers to 2026-06-19 (v3.11.0).
- Ignore local `.claude/` session files (can capture tokens).

After merge: tag `v3.11.0` and publish the GitHub Release, which triggers the
Homebrew tap update via `release-tap.yml`.