### PR TITLE
Fix _xml_escape on bash >= 5.2 (patsub_replacement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
+## [Unreleased]
+### Fixed
+
+- **Service file XML escaping on bash ≥ 5.2.** `_xml_escape` built entities with
+  bash `${var//pat/repl}` substitution, but bash 5.2+ enables `patsub_replacement`
+  by default, so an unescaped `&` in the replacement expands to the matched text —
+  turning `<`/`>` into `<lt;`/`>gt;` instead of `&lt;`/`&gt;`. A VPN profile name
+  containing `<` or `>` therefore produced a malformed launchd plist / systemd unit.
+  Escaping now uses `sed` (`\&` is an unambiguous literal across bash versions).
+
+---
+
 ## [v3.11.0] — 2026-06-19
 ### Added
 

--- a/service.sh
+++ b/service.sh
@@ -12,7 +12,12 @@ LAUNCH_AGENT_DIR="${VPN_UP_LAUNCH_AGENT_DIR:-$HOME/Library/LaunchAgents}"
 SYSTEMD_USER_DIR="${VPN_UP_SYSTEMD_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
 SERVICE_LABEL_PREFIX="com.sorinipate.vpn-up"
 
-_xml_escape() { local s="$1"; s="${s//&/&amp;}"; s="${s//</&lt;}"; s="${s//>/&gt;}"; printf '%s' "$s"; }
+# Escape &, <, > for XML/plist/unit content. Done via sed, not bash ${//}
+# substitution: under bash >= 5.2 `patsub_replacement` is on by default, so an
+# unescaped `&` in a ${var//pat/repl} replacement expands to the matched text
+# (e.g. ${s//</&lt;} yields "<lt;", not "&lt;"). sed's `\&` is an unambiguous
+# literal ampersand across all bash versions. `&` must be escaped first.
+_xml_escape() { printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'; }
 
 _service_path_for() {
   local slug; slug="$(profile_slug "$1")"

--- a/tests/clientcert.bats
+++ b/tests/clientcert.bats
@@ -165,3 +165,23 @@ XML
   [ "$status" -eq 0 ]
   [[ "$output" == *"key_password"* ]]
 }
+
+# --- _append_pkcs11_pin_source (pure URI builder) ---
+
+@test "_append_pkcs11_pin_source returns non-pkcs11 URIs and file paths unchanged" {
+  run _append_pkcs11_pin_source "/etc/vpn/me.key" "/run/pin"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/etc/vpn/me.key" ]
+}
+
+@test "_append_pkcs11_pin_source appends pin-source with '?' when the URI has no query" {
+  run _append_pkcs11_pin_source "pkcs11:manufacturer=piv_II;id=%01" "/run/pin"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkcs11:manufacturer=piv_II;id=%01?pin-source=file:/run/pin" ]
+}
+
+@test "_append_pkcs11_pin_source appends pin-source with '&' when the URI already has a query" {
+  run _append_pkcs11_pin_source "pkcs11:id=%01?type=cert" "/run/pin"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkcs11:id=%01?type=cert&pin-source=file:/run/pin" ]
+}

--- a/tests/service.bats
+++ b/tests/service.bats
@@ -14,6 +14,27 @@ setup() {
   source "$BATS_TEST_DIRNAME/../service.sh"
 }
 
+@test "_xml_escape escapes &, <, > and leaves plain text untouched" {
+  [ "$(_xml_escape "plain text")" = "plain text" ]
+  [ "$(_xml_escape "a & b")" = "a &amp; b" ]
+  [ "$(_xml_escape "1 < 2")" = "1 &lt; 2" ]
+  [ "$(_xml_escape "2 > 1")" = "2 &gt; 1" ]
+  [ "$(_xml_escape "<tag attr=\"x\">")" = "&lt;tag attr=\"x\"&gt;" ]
+}
+
+@test "_xml_escape escapes ampersand first so entities are not double-escaped" {
+  # An input that already looks like an entity must not become &amp;lt;
+  [ "$(_xml_escape "&lt;")" = "&amp;lt;" ]
+  [ "$(_xml_escape "A < B & C > D")" = "A &lt; B &amp; C &gt; D" ]
+}
+
+@test "_xml_escape output for an injection-y profile name yields well-formed XML in the plist" {
+  run write_launch_agent_plist 'Evil</string><key>x</key><string>& <oops>'
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | xmlstarlet val -q -
+  [[ "$output" != *"<oops>"* ]]   # the literal '<' was escaped, not emitted as a tag
+}
+
 @test "write_launch_agent_plist produces valid plist with service env and profile" {
   run write_launch_agent_plist "My Work & VPN"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Bug

`_xml_escape` (service.sh) built XML entities with bash `${var//pat/repl}`
substitution. Under **bash >= 5.2** `patsub_replacement` is on by default, so an
unescaped `&` in the replacement expands to the *matched text* — `${s//</&lt;}`
yields `<lt;`, not `&lt;`. (The `&`->`&amp;` case worked only by luck: there the
match *is* `&`.)

**Impact:** a VPN profile name containing `<` or `>` produced a **malformed
launchd plist / systemd unit** on modern Linux and Homebrew bash. CI never caught
it because the only escaping test used `&`.

## Fix

Rewrite `_xml_escape` with `sed`, where `\&` is an unambiguous literal ampersand
across all bash versions; comment the trap so it isn't "simplified" back.

## Tests

- `tests/service.bats`: direct `_xml_escape` tests — `&`/`<`/`>`, escape ordering
  (ampersand first), and an injection-style profile name must still produce
  well-formed XML (validated with `xmlstarlet`).
- `tests/clientcert.bats`: direct `_append_pkcs11_pin_source` branch tests
  (non-`pkcs11:` passthrough, `?` vs `&` separator) — found under-covered while
  auditing.
- Full suite: **123/123 pass**; `shellcheck --shell=bash --external-sources` clean.

Scanned the rest of the tree for the same `&`-in-replacement pattern — no other
instances.