### PR TITLE
Release v3.11.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — VPN Up for OpenConnect
 
-**Last updated:** 2026-06-19 (v3.11.0)
+**Last updated:** 2026-06-19 (v3.11.1)
 
 > *What* and *why* live in [PRD.md](PRD.md); this document covers *how*. Function and
 > file references are accurate as of the version above — verify against the source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is inspired by *Keep a Changelog* and this project adheres to **Seman
 
 ---
 
-## [Unreleased]
+## [v3.11.1] — 2026-06-19
 ### Fixed
 
 - **Service file XML escaping on bash ≥ 5.2.** `_xml_escape` built entities with

--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
 # Product Requirements Document — VPN Up for OpenConnect
 
-**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-19 (v3.11.0)
+**Status:** Living document · **Owner:** Sorin-Doru Ipate · **Last updated:** 2026-06-19 (v3.11.1)
 
 > This PRD describes *what* VPN Up is and *why*. For *how* it's built, see
 > [ARCHITECTURE.md](ARCHITECTURE.md). For the change history, see

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Secure, scriptable command-line VPN client for Cisco AnyConnect and other SSL VPNs, built on OpenConnect — for macOS & Linux.
 
 [![CI](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/sorinipate/vpn-up-for-openconnect/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v3.11.0-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
+[![Release](https://img.shields.io/badge/release-v3.11.1-blue)](https://github.com/sorinipate/vpn-up-for-openconnect/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://sorinipate.github.io/vpn-up-for-openconnect/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue)


### PR DESCRIPTION
Stamps the **v3.11.1** patch release.

- Promote the `[Unreleased]` CHANGELOG section → `[v3.11.1] — 2026-06-19`
  (the `_xml_escape` bash ≥ 5.2 / `patsub_replacement` fix, from #81).
- Bump the README release badge to v3.11.1.
- Update the ARCHITECTURE / PRD "Last updated" headers to v3.11.1.

After merge: tag `v3.11.1` and publish the GitHub Release, which triggers the
Homebrew tap update via `release-tap.yml`.